### PR TITLE
Use debug logging for testsummaries

### DIFF
--- a/xcodeutil/testsummaries/testsummaries.go
+++ b/xcodeutil/testsummaries/testsummaries.go
@@ -2,10 +2,10 @@ package testsummaries
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 	"time"
 
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/plistutil"
 	"github.com/bitrise-steplib/steps-xcode-test/pretty"
 )
@@ -78,7 +78,7 @@ func parseTestSummaries(testSummariesContent plistutil.PlistData) ([]TestResult,
 			if err != nil {
 				return nil, err
 			}
-			log.Printf("lastSubtests %s", pretty.Object(lastSubtests))
+			log.Debugf("lastSubtests %s", pretty.Object(lastSubtests))
 
 			for _, test := range lastSubtests {
 				testID, found := test.GetString("TestIdentifier")
@@ -104,7 +104,7 @@ func parseTestSummaries(testSummariesContent plistutil.PlistData) ([]TestResult,
 				{
 					activitySummariesData, found := test.GetMapStringInterfaceArray("ActivitySummaries")
 					if !found {
-						log.Printf("no activity summaries found for test: %s", test)
+						log.Infof("no activity summaries found for test: %s", test)
 					}
 					activitySummaries, err = parseActivites(activitySummariesData)
 					if err != nil {
@@ -196,7 +196,7 @@ func parseActivites(activitySummariesData []plistutil.PlistData) ([]Activity, er
 				return nil, err
 			}
 		} else {
-			log.Printf("No subactivities found for activity: %s", pretty.Object(activity))
+			log.Debugf("No subactivities found for activity: %s", pretty.Object(activity))
 		}
 		activities[i] = Activity{
 			Title:         title,


### PR DESCRIPTION
The xcode-test step is logging a large amount of data during normal execution, which seems undesirable. I reduced the log level of some of this output to debug level. This way the output will be hidden normally but can still be viewed when needed by turning on verbose mode.

The "lastSubtests" and "No subactivities found for activity" logs are producing most of the output for my builds and seem to be purely informational.

If "No subactivities found for activity" is truely a warning that needs to be heeded by the user, then the message might be better as an info or warn level. Otherwise, if it's not something that the user needs to worry about, and was put there for debugging while coding the step, then I think debug level is most appropriate.

Along a similar vein, if the "no activity summaries found for test" is notifying the user of something that shouldn't normally happen, then an info or warn level might be more appropriate.

I've set all 3 to debug level in this PR, but can change it depending on feedback of the maintainers.