### PR TITLE
TOOL-1853 test summary fix, step.yml corrections

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -243,7 +243,7 @@ inputs:
   - should_build_before_test: "yes"
     opts:
       category: Debug
-      title: "(Experimental) Explicitly perform a build before testing?"
+      title: "Should run a build before testing?"
       description: |-
         Previous Xcode versions and configurations may throw the error `iPhoneSimulator: Timed out waiting 120 seconds for simulator to boot, current state is 1.`
         when the compilation before performing the tests takes too long.
@@ -259,7 +259,7 @@ inputs:
   - should_retry_test_on_fail: "no"
     opts:
       category: Debug
-      title: "(Experimental) Rerun test, when it fails?"
+      title: "Should retry test on failure?"
       description: |-
         If `should_retry_test_on_fail: yes` step will retry the test if first attempt failed.
       value_options:
@@ -279,7 +279,7 @@ inputs:
 
         In case of leaving this input on default value:
 
-        `set -o pipefail && XCODEBUILD_TEST_COMMAND | xcpretty --color --report html --color --report html --output "${BITRISE_DEPLOY_DIR}/xcode-test-results-${BITRISE_SCHEME}.html"
+        `set -o pipefail && XCODEBUILD_TEST_COMMAND | xcpretty --color --report html --output "${BITRISE_DEPLOY_DIR}/xcode-test-results-${BITRISE_SCHEME}.html"
 
         If you want to add more options, list that separated by space character.
   - cache_level: swift_packages

--- a/xcodeutil/testsummaries/testsummaries.go
+++ b/xcodeutil/testsummaries/testsummaries.go
@@ -102,13 +102,11 @@ func parseTestSummaries(testSummariesContent plistutil.PlistData) ([]TestResult,
 				}
 				var activitySummaries []Activity
 				{
-					activitySummariesData, found := test.GetMapStringInterfaceArray("ActivitySummaries")
-					if !found {
-						log.Infof("no activity summaries found for test: %s", test)
-					}
-					activitySummaries, err = parseActivites(activitySummariesData)
-					if err != nil {
-						return nil, fmt.Errorf("failed to parse activities, error: %s", err)
+					if activitySummariesData, found := test.GetMapStringInterfaceArray("ActivitySummaries"); found {
+						activitySummaries, err = parseActivites(activitySummariesData)
+						if err != nil {
+							return nil, fmt.Errorf("failed to parse activities, error: %s", err)
+						}
 					}
 				}
 				testResults = append(testResults, TestResult{

--- a/xcodeutil/testsummaries/testsummaries_test.go
+++ b/xcodeutil/testsummaries/testsummaries_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bitrise-steplib/steps-xcode-test/pretty"
 	"github.com/bitrise-io/go-xcode/plistutil"
+	"github.com/bitrise-steplib/steps-xcode-test/pretty"
 )
 
 func TestTimestampToTime(t *testing.T) {
@@ -74,7 +74,7 @@ func Test_parseTestSummaries(t *testing.T) {
 					ID:          testID,
 					Status:      testStatus,
 					FailureInfo: nil,
-					Activities:  make([]Activity, 0),
+					Activities:  nil,
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
fixes:
- Xcode Test step search for activity even in Unit test results
- steps-xcode-test : --color --report repeated twice
- iOS Build - [Xcode Test for iOS] Debug Option - ShouldBuildBeforeTest value defaults to "No" but shows as 'true' in logs