### PR TITLE
Individual Test Retry

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -255,6 +255,8 @@ workflows:
         - output_tool: $OUTPUT_TOOL
         - is_clean_build: "yes"
         - should_retry_test_on_fail: $RETRY_ON_FAIL
+        - should_retry_individual_failures: $RETRY_INDIVIDUAL_FAILURES
+        - test_failure_retry_limit: $TEST_FAILURE_RETRY_LIMIT
         - generate_code_coverage_files: "no"
         - simulator_device: $SIMULATOR_DEVICE
         - simulator_os_version: $SIMULATOR_OS_VERSION
@@ -382,6 +384,8 @@ workflows:
         - output_tool: $OUTPUT_TOOL
         - is_clean_build: "no"
         - should_retry_test_on_fail: $RETRY_ON_FAIL
+        - should_retry_individual_failures: $RETRY_INDIVIDUAL_FAILURES
+        - test_failure_retry_limit: $TEST_FAILURE_RETRY_LIMIT
         - generate_code_coverage_files: "no"
         - simulator_device: $SIMULATOR_DEVICE
         - simulator_os_version: latest

--- a/command/command.go
+++ b/command/command.go
@@ -83,6 +83,12 @@ func CreateXcprettyCmd(xcprettydArgs ...string) *exec.Cmd {
 	return exec.Command("xcpretty", xcprettydArgs...)
 }
 
+// Create XcTestResultCmd ...
+// This command is only useful for Xcode builds whoes major version is greater than or eqaul to 11.
+func CreateXcTestResultCmd(testResultPath string) *exec.Cmd {
+	return exec.Command("xcrun", "xcresulttool", "get", "--path", testResultPath, "--format", "json")
+}
+
 // Zip ...
 func Zip(targetDir, targetRelPathToZip, zipPath string) error {
 	zipCmd := exec.Command("/usr/bin/zip", "-rTy", zipPath, targetRelPathToZip)

--- a/main.go
+++ b/main.go
@@ -291,7 +291,7 @@ func runTest(buildTestParams models.XcodeBuildTestParamsModel, outputTool, xcpre
 						newOutputDir = buildTestParams.TestOutputDir[0:lastSlashIndex]
 					}
 
-					newOutputDir = path.Join(newOutputDir, "Test_Retry_" + string(currentAttempt) + ".xcresult")
+					newOutputDir = path.Join(newOutputDir, "Test_Retry_"+string(currentAttempt)+".xcresult")
 
 					newBuildTestParams := models.XcodeBuildTestParamsModel{
 						buildTestParams.BuildParams,

--- a/main.go
+++ b/main.go
@@ -255,7 +255,7 @@ func runTest(buildTestParams models.XcodeBuildTestParamsModel, outputTool, xcpre
 		// If the currentAttempt is greater than the limit, we are out of retries so we will skip out.
 		// Or if there are no retries set we will also skip out.
 		if (currentAttempt > retryLimit) || !(isAutomaticRetryOnReason || isRetryIndividualFailures || isRetryOnFail) {
-			log.Errorf("isAutomaticRetryOnReason=%v, isRetryOnFail=%v, isRetryIndividualFailures=%v is no more retry, stopping the test!", isAutomaticRetryOnReason, isRetryOnFail, isRetryIndividualFailures)
+			log.Errorf("isAutomaticRetryOnReason=%v, isRetryOnFail=%v, isRetryIndividualFailures=%v no more retry, stopping the test!", isAutomaticRetryOnReason, isRetryOnFail, isRetryIndividualFailures)
 			return fullOutputStr, exitCode, testError
 		}
 
@@ -284,9 +284,18 @@ func runTest(buildTestParams models.XcodeBuildTestParamsModel, outputTool, xcpre
 				// was successful and we can proceed with the retry without building again. If there are no test failures,
 				// we assume that there was an issue with the build, so we want to allow rebuilding.
 				if len(failurePaths) > 0 {
+					newOutputDir := ""
+					lastSlashIndex := strings.LastIndex(buildTestParams.TestOutputDir, "/")
+
+					if lastSlashIndex >= 0 {
+						newOutputDir = buildTestParams.TestOutputDir[0:lastSlashIndex]
+					}
+
+					newOutputDir = path.Join(newOutputDir, "Test_Retry_" + string(currentAttempt) + ".xcresult")
+
 					newBuildTestParams := models.XcodeBuildTestParamsModel{
 						buildTestParams.BuildParams,
-						buildTestParams.TestOutputDir,
+						newOutputDir,
 						false, // Clean build is false
 						false, // Build before test is false
 						buildTestParams.GenerateCodeCoverage,

--- a/models/models.go
+++ b/models/models.go
@@ -1,5 +1,9 @@
 package models
 
+import (
+	"strings"
+)
+
 //=======================================
 // Models
 //=======================================
@@ -23,4 +27,100 @@ type XcodeBuildTestParamsModel struct {
 	BuildBeforeTest      bool
 	GenerateCodeCoverage bool
 	AdditionalOptions    string
+}
+
+//=======================================
+// xcresulttool models useful for Xcode
+// versions greater than or equal to 11.
+//=======================================
+
+// XcodeActionsInvocationRecord ...
+// based on Xcode Result Types Version: 3.24
+type XcodeActionsInvocationRecord struct {
+	Type   TypeStruct              `json:"_type"`
+	Issues XcodeResultIssueSummary `json:"issues"`
+}
+
+// TestFailures returns a slice of the test paths that failed.
+func (r *XcodeActionsInvocationRecord) TestFailures() []string {
+	failures := []string{}
+
+	for _, failure := range r.Issues.TestFailureSummaries.Values {
+        failures = append(failures, failure.TestPath())
+	}
+
+	return failures
+}
+
+// XcodeResultIssueSummary ...
+// based on Xcode Result Types Version: 3.24
+type XcodeResultIssueSummary struct {
+	Type                 TypeStruct                              `json:"_type"`
+	ErrorSummaries       XcodeIssueSummaryArrayStruct            `json:"errorSummaries"`
+	TestFailureSummaries XcodeTestFailureIssueSummaryArrayStruct `json:"testFailureSummaries"`
+}
+
+// XcodeIssueSummaryArrayStruct ...
+// based on Xcode Result Types Version: 3.24
+type XcodeIssueSummaryArrayStruct struct {
+	Type   TypeStruct          `json:"_type"`
+	Values []XcodeIssueSummary `json:"_values"`
+}
+
+// XcodeTestFailureIssueSummaryArrayStruct ...
+// based on Xcode Result Types Version: 3.24
+type XcodeTestFailureIssueSummaryArrayStruct struct {
+	Type   TypeStruct                     `json:"_type"`
+	Values []XcodeTestFailureIssueSummary `json:"_values"`
+}
+
+// XcodeIssueSummary ...
+// based on Xcode Result Types Version: 3.24
+type XcodeIssueSummary struct {
+	Type                                TypeStruct            `json:"_type"`
+	IssueType                           StringStruct          `json:"issueType"`
+	Message                             StringStruct          `json:"message"`
+	ProducingTarget                     StringStruct          `json:"producingTarget"`
+	DocumentLocationInCreatingWorkspace XcodeDocumentLocation `json:"documentLocationInCreatingWorkspace"`
+}
+
+// XcodeTestFailureIssueSummary ...
+// based on Xcode Result Types Version: 3.24
+type XcodeTestFailureIssueSummary struct {
+	Type                                TypeStruct            `json:"_type"`
+	IssueType                           StringStruct          `json:"issueType"`
+	Message                             StringStruct          `json:"message"`
+	ProducingTarget                     StringStruct          `json:"producingTarget"`
+	DocumentLocationInCreatingWorkspace XcodeDocumentLocation `json:"documentLocationInCreatingWorkspace"`
+	TestCaseName                        StringStruct          `json:"testCaseName"`
+}
+
+// TestPath returns the string representation of the test path that failed.
+func (s *XcodeTestFailureIssueSummary) TestPath() string {
+	testCase := strings.ReplaceAll(s.TestCaseName.Value, ".", "/")
+	testCase = strings.ReplaceAll(testCase, "(", "")
+	testCase = strings.ReplaceAll(testCase, ")", "")
+
+	return s.ProducingTarget.Value + "/" + testCase
+}
+
+// XcodeDocumentLocation ...
+// based on Xcode Result Types Version: 3.24
+type XcodeDocumentLocation struct {
+	Type             TypeStruct   `json:"_type"`
+	Url              StringStruct `json:"url"`
+	ConcreteTypeName StringStruct `json:"concreteTypeName"`
+}
+
+// TypeStruct ...
+// based on Xcode Result Types Version: 3.24
+type TypeStruct struct {
+	Name string `json:"_name"`
+}
+
+// StringStruct ...
+// based on Xcode Result Types Version: 3.24
+type StringStruct struct {
+	Type  TypeStruct `json:"_type"`
+	Value string     `json:"_value"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -27,6 +27,7 @@ type XcodeBuildTestParamsModel struct {
 	BuildBeforeTest      bool
 	GenerateCodeCoverage bool
 	AdditionalOptions    string
+	OnlyTestOptions      string
 }
 
 //=======================================
@@ -46,7 +47,7 @@ func (r *XcodeActionsInvocationRecord) TestFailures() []string {
 	failures := []string{}
 
 	for _, failure := range r.Issues.TestFailureSummaries.Values {
-        failures = append(failures, failure.TestPath())
+		failures = append(failures, failure.TestPath())
 	}
 
 	return failures

--- a/step.yml
+++ b/step.yml
@@ -266,6 +266,27 @@ inputs:
         - "yes"
         - "no"
       is_required: true
+  - should_retry_individual_failures: "no"
+    opts:
+      category: Debug
+      title: "Should retry individual test failures?"
+      description: |-
+        If `should_retry_individual_failures: yes` setp will retry only the individual tests that failed without cleaning or rebuilding. 
+      value_options:
+        - "yes"
+        - "no"
+  - test_failure_retry_limit: 1
+    opts:
+      category: Debug
+      title: "Test failure retry attempts limit"
+      description: |-
+        The number of retry attempts that can be made.
+      value_options:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
   - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/xcode-test-results-${BITRISE_SCHEME}.html"
     opts:
       category: Debug


### PR DESCRIPTION
# Summary

This change adds the ability to retry individual tests on test failure. In addition to the automatic retry on reason and retry on fail flags, this change adds an individual retry flag that, if enabled, overrides the retry on fail so that only the tests that failed are retried. 

When enabled, the number of retries is governed by the `TEST_FAILURE_RETRY_LIMIT` hand can be set to `{1,2,3,4,5}`. 

In the interest of saving time for the CI build, this change assumes that if there were test failures, the target built successfully and the tests executed, so there should be no need to rebuild the target and uses the `build-without-testing` action. If the test action fails but there are no test failures, the assumption is that there was an issue with building the target and the typical retry path of rebuilding the target and running all tests is taken. 

# Note
The retry functionality uses the new `xcresult` format and is only available for Xcode builds with major version greater than or equal to 11.