### PR TITLE
Saves log on success

### DIFF
--- a/main.go
+++ b/main.go
@@ -592,12 +592,12 @@ func main() {
 	}
 
 	buildParams := models.XcodeBuildParamsModel{
-		Action:                     action,
-		ProjectPath:                absProjectPath,
-		Scheme:                     configs.Scheme,
-		DeviceDestination:          deviceDestination,
-		CleanBuild:                 configs.IsCleanBuild,
-		DisableIndexWhileBuilding:  configs.DisableIndexWhileBuilding,
+		Action:                    action,
+		ProjectPath:               absProjectPath,
+		Scheme:                    configs.Scheme,
+		DeviceDestination:         deviceDestination,
+		CleanBuild:                configs.IsCleanBuild,
+		DisableIndexWhileBuilding: configs.DisableIndexWhileBuilding,
 	}
 
 	buildTestParams := models.XcodeBuildTestParamsModel{

--- a/step.yml
+++ b/step.yml
@@ -266,6 +266,16 @@ inputs:
         - "yes"
         - "no"
       is_required: true
+- should_save_log_file_on_success: "no"
+  opts:
+    category: Debug
+    title: "Should save log file on success?"
+    description: |-
+      If `should_save_log_file_on_success: yes` step will save the log file not only on failure but also in success.
+    value_options:
+      - "yes"
+      - "no"
+    is_required: true
   - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/xcode-test-results-${BITRISE_SCHEME}.html"
     opts:
       category: Debug

--- a/step.yml
+++ b/step.yml
@@ -266,16 +266,16 @@ inputs:
         - "yes"
         - "no"
       is_required: true
-- should_save_log_file_on_success: "no"
-  opts:
-    category: Debug
-    title: "Should save log file on success?"
-    description: |-
-      If `should_save_log_file_on_success: yes` step will save the log file not only on failure but also in success.
-    value_options:
-      - "yes"
-      - "no"
-    is_required: true
+  - should_save_log_file_on_success: "no"
+    opts:
+      category: Debug
+      title: "Should save log file on success?"
+      description: |-
+        If `should_save_log_file_on_success: yes` step will save the log file not only on failure but also in success.
+      value_options:
+        - "yes"
+        - "no"
+      is_required: true
   - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/xcode-test-results-${BITRISE_SCHEME}.html"
     opts:
       category: Debug


### PR DESCRIPTION
This change adds the option to save the log when there is a successful build, by default will be turned off.
We need this to gather valuable information of the build as number of warnings per target, number of tests per target, duration of tests per target, path of the generated .app so we can track its size via a test, build duration, etc..