### PR TITLE
Support Swift package without -project or -workspace

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,7 +213,11 @@ func runPrettyXcodeBuildCmd(useStdOut bool, xcprettyArgs []string, xcodebuildArg
 }
 
 func runBuild(buildParams models.XcodeBuildParamsModel, outputTool string) (string, int, error) {
-	xcodebuildArgs := []string{buildParams.Action, buildParams.ProjectPath, "-scheme", buildParams.Scheme}
+	xcodebuildArgs := []string{}
+	if !buildParams.SPM {
+		xcodebuildArgs = append(xcodebuildArgs, buildParams.Action, buildParams.ProjectPath)
+	}
+	xcodebuildArgs = append(xcodebuildArgs, "-scheme", buildParams.Scheme)
 	if buildParams.CleanBuild {
 		xcodebuildArgs = append(xcodebuildArgs, "clean")
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -12,6 +12,7 @@ type XcodeBuildParamsModel struct {
 	DeviceDestination         string
 	CleanBuild                bool
 	DisableIndexWhileBuilding bool
+	SPM                       bool
 }
 
 // XcodeBuildTestParamsModel ...

--- a/step.yml
+++ b/step.yml
@@ -53,10 +53,10 @@ toolkit:
 inputs:
   - project_path: $BITRISE_PROJECT_PATH
     opts:
-      title: "Project (or Workspace) path"
+      title: "Project (or Workspace or Package.swift) path"
       description: |-
         A `.xcodeproj` or `.xcworkspace` path, relative to
-        the Working directory (if specified).
+        the Working directory (if specified). If this is a Swift package, this should be the path to the Package.swift file.
       is_required: true
   - scheme: $BITRISE_SCHEME
     opts:

--- a/vendor/github.com/bitrise-io/go-xcode/xcodecache/swiftpm_cache.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodecache/swiftpm_cache.go
@@ -21,11 +21,13 @@ func SwiftPackagesPath(xcodeProjectPath string) (string, error) {
 		return "", fmt.Errorf("project path not an absolute path: %s", xcodeProjectPath)
 	}
 
-	if !strings.HasSuffix(xcodeProjectPath, ".xcodeproj") && !strings.HasSuffix(xcodeProjectPath, ".xcworkspace") {
-		return "", fmt.Errorf("invalid Xcode project path %s, no .xcodeproj or .xcworkspace suffix found", xcodeProjectPath)
+	if !strings.HasSuffix(xcodeProjectPath, ".xcodeproj") && !strings.HasSuffix(xcodeProjectPath, ".xcworkspace") && !strings.HasSuffix(xcodeProjectPath, "Package.swift") {
+		return "", fmt.Errorf("invalid Xcode project path %s, no .xcodeproj or .xcworkspace suffix, or Package.swift file found", xcodeProjectPath)
 	}
 
-	projectDerivedData, err := xcodeProjectDerivedDataPath(xcodeProjectPath)
+	trimmedXcodeProjectPath := strings.TrimSuffix(xcodeProjectPath, "/Package.swift")
+
+	projectDerivedData, err := xcodeProjectDerivedDataPath(trimmedXcodeProjectPath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This updates the step to build and test Swift packages that don't contain an .xcworkspace or .xcodeproj file. This is enabled by setting the `project_path` to the path of the Package.swift file. This should resolve #148. 