### PR TITLE
xcrun simctl list empty devices fix

### DIFF
--- a/vendor/github.com/bitrise-io/go-xcode/simulator/simulator.go
+++ b/vendor/github.com/bitrise-io/go-xcode/simulator/simulator.go
@@ -181,7 +181,7 @@ func getLatestSimulatorInfoFromSimctlOut(simctlListOut, osName, deviceName strin
 	}
 
 	if latestVersionPtr == nil {
-		return InfoModel{}, "", fmt.Errorf("failed to determin latest (%s) simulator version", osName)
+		return InfoModel{}, "", fmt.Errorf("failed to determine latest (%s) simulator version", osName)
 	}
 
 	versionSegments := latestVersionPtr.Segments()


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MAJOR / MINOR / PATCH_ [version update](https://semver.org/)
I am not sure how you manage the version updates? But feel free to explain me and I update the version

### Context

When the step runs xcrun simctl list sometimes the device list is empty and it cant find the right simulator, this gives us errors like these:
error: no simulators found for os version: iOS 14.1
error: failed to determin latest (iOS) simulator version

It doesn't matter if we specify the os version or we use latest since the device list is empty, I confirmed this by connecting to the vm via ssh and running multiple times xcrun simctl list, I removed extra device types and runtime to reduce the log here, as you can see the first time there are no devices but the second time it shows them, this might be some Apple error where the devices are not ready when running the command.

```
omarzl@mbp-omar steps-xcode-test-master % ssh -o StrictHostKeyChecking=no vagrant@3.tcp.ngrok.io -p 21127
Warning: Permanently added the ECDSA host key for IP address '[13.59.222.135]:21127' to the list of known hosts.
vagrant@3.tcp.ngrok.io's password: 
Last login: Thu Apr  8 00:19:51 2021
vagrant@prd-atl-elt-g-xcode-12-1-210407231855-WruxS4WMMdN7UWGu5g3di6 ~ % xcrun simctl list 
== Device Types ==
iPhone 4s (com.apple.CoreSimulator.SimDeviceType.iPhone-4s)
iPhone 5 (com.apple.CoreSimulator.SimDeviceType.iPhone-5)
...
== Runtimes ==
iOS 13.3 (13.3 - 17C45) - com.apple.CoreSimulator.SimRuntime.iOS-13-3
iOS 13.4 (13.4 - 17E255) - com.apple.CoreSimulator.SimRuntime.iOS-13-4
...
== Devices ==
-- iOS 13.3 --
-- iOS 13.4 --
-- iOS 13.5 --
-- iOS 13.6 --
-- iOS 14.0 --
-- iOS 14.1 --
-- tvOS 13.0 --
-- tvOS 13.2 --
-- tvOS 13.3 --
-- tvOS 14.0 --
-- watchOS 6.0 --
-- watchOS 6.1 --
-- watchOS 7.0 --
== Device Pairs ==


vagrant@prd-atl-elt-g-xcode-12-1-210407231855-WruxS4WMMdN7UWGu5g3di6 ~ % xcrun simctl list
== Device Types ==
iPhone 4s (com.apple.CoreSimulator.SimDeviceType.iPhone-4s)
iPhone 5 (com.apple.CoreSimulator.SimDeviceType.iPhone-5)
...
== Runtimes ==
iOS 13.3 (13.3 - 17C45) - com.apple.CoreSimulator.SimRuntime.iOS-13-3
iOS 13.4 (13.4 - 17E255) - com.apple.CoreSimulator.SimRuntime.iOS-13-4
...
== Devices ==
-- iOS 13.3 --
    iPhone 8 (234DFD9E-6981-45E9-87D7-2600CBF8850F) (Shutdown) 
    iPhone 8 Plus (3F6772FB-5FD0-4B06-9AA9-687ED8468608) (Shutdown) 
    iPhone 11 (9CA63DDB-8132-413F-86BD-3697649F1F2C) (Shutdown) 
    iPhone 11 Pro (D7762EFF-8BA4-4192-944A-3CE26A7A63E8) (Shutdown) 
    iPhone 11 Pro Max (8F1729ED-5355-451D-8B3A-13C33E84C325) (Shutdown) 
    iPad Pro (9.7-inch) (194EAF3A-2473-434E-82DD-42E39F017F20) (Shutdown) 
    iPad (7th generation) (5D0AA9BD-1098-4F2A-B58E-ACE74B1CD96D) (Shutdown) 
    iPad Pro (11-inch) (1st generation) (7A47CB5C-135E-4A25-B94B-68F2FE3DEDEA) (Shutdown) 
    iPad Pro (12.9-inch) (3rd generation) (D54352B3-D805-4322-A2B3-67D28FABD300) (Shutdown) 
    iPad Air (3rd generation) (CA00CBCC-8A91-4951-826E-24B89238555B) (Shutdown) 
-- iOS 13.4 --
    iPhone 8 (F269656D-4526-4034-8878-A8EE8D8FD257) (Shutdown) 
    iPhone 8 Plus (BCAC2ED2-5DF9-43B7-9C1A-8AD7029496D6) (Shutdown) 
    iPhone 11 (984E7339-3FBC-4150-82B4-FB1976F36019) (Shutdown) 
    iPhone 11 Pro (8D7E356C-FA37-4578-B14D-FB6FD90F2E97) (Shutdown) 
    iPhone 11 Pro Max (B9154231-D67D-4824-976A-B282AD1C28BF) (Shutdown) 
    iPad Pro (9.7-inch) (F1F36900-AD09-46D3-8457-04FB6F290BCF) (Shutdown) 
    iPad (7th generation) (EB795B19-D20C-41D8-8F3B-B5F0DEBF91BD) (Shutdown) 
    iPad Pro (11-inch) (2nd generation) (0213B621-1C8B-497E-A6A5-7C78BDD6AD29) (Shutdown) 
    iPad Pro (12.9-inch) (4th generation) (8F83C17D-FAE8-4A5B-AE7A-D099F2F3E083) (Shutdown) 
    iPad Air (3rd generation) (70B9973D-9B20-4C90-A843-210AACBA57C1) (Shutdown) 
-- iOS 13.5 --
    iPhone 8 (5E1DC067-E9F9-4A8F-A76E-A2B3C4611384) (Shutdown) 
    iPhone 8 Plus (BE292225-B50E-4A49-8BCE-50C62203532E) (Shutdown) 
    iPhone 11 (3BCD650C-9E38-4E3C-B0A5-D651191A768C) (Shutdown) 
    iPhone 11 Pro (7E4E2CF1-6AB3-4991-B430-81A85F3CD64C) (Shutdown) 
    iPhone 11 Pro Max (6F5804E6-3F0F-4985-A4BD-5CFF6F4F88F6) (Shutdown) 
    iPhone SE (2nd generation) (2CBBB95C-33C8-4495-B6A8-6AC340FA45B5) (Shutdown) 
    iPad Pro (9.7-inch) (218E18BA-3129-485E-BFA9-13099AF980E0) (Shutdown) 
    iPad (7th generation) (EDF752AC-E5AF-486C-8252-265136406929) (Shutdown) 
    iPad Pro (11-inch) (2nd generation) (17CB833B-63B2-4B30-8371-5BE4066AF0FA) (Shutdown) 
    iPad Pro (12.9-inch) (4th generation) (F97588DF-50E1-4AA9-A9D2-0211A7661150) (Shutdown) 
    iPad Air (3rd generation) (68E56C59-5EA6-4B08-94C9-7F8350F5D8F6) (Shutdown) 
-- iOS 13.6 --
    iPhone 8 (2A03E809-AEF0-40ED-8FDD-7532CE2E136A) (Shutdown) 
    iPhone 8 Plus (40DF685D-FF29-4BC9-899B-812EA3F96C4E) (Shutdown) 
    iPhone 11 (1DA473BE-2A23-4113-A09B-8E913E501AE5) (Shutdown) 
    iPhone 11 Pro (9A7EA57E-C53D-4930-B0F5-CBD591A078B5) (Shutdown) 
    iPhone 11 Pro Max (D11B0543-69D0-4DC4-A2EF-5EA88E24864E) (Shutdown) 
    iPhone SE (2nd generation) (FB41ADCA-94C8-47A2-96B1-852DAB8BE00D) (Shutdown) 
    iPad Pro (9.7-inch) (FFFAD0DB-6106-49BB-8946-34F60C1EF29F) (Shutdown) 
    iPad (7th generation) (A8DFC0FE-FF1C-4E69-AD1E-AAC202177349) (Shutdown) 
    iPad Pro (11-inch) (2nd generation) (748A8DA3-29BC-4586-97AD-CB1CE1984778) (Shutdown) 
    iPad Pro (12.9-inch) (4th generation) (2F465E9F-6D4C-4443-B7FF-79FC5D1E11F1) (Shutdown) 
    iPad Air (3rd generation) (8125C8E7-7427-4BB3-A373-79968D1B98DE) (Shutdown) 
-- iOS 14.0 --
    iPhone 8 (C7402677-D5EF-42F6-A14E-3DA337B6D652) (Shutdown) 
    iPhone 8 Plus (9F298ADA-60B9-4BC7-8EB0-3848DDC15599) (Shutdown) 
    iPhone 11 (1E36BFCB-C087-46C9-B5F9-F960ACE95B38) (Shutdown) 
    iPhone 11 Pro (AE0E3DDE-8742-437E-B13F-67AD88476D8F) (Shutdown) 
    iPhone 11 Pro Max (3C0E7637-94BC-44BD-B075-8153E0F63B0E) (Shutdown) 
    iPhone SE (2nd generation) (B727B6E2-5548-4C06-A8B7-F5A98BC97C1B) (Shutdown) 
    iPod touch (7th generation) (77A2E4EB-7600-4AFA-AC1C-0C0669159C4D) (Shutdown) 
    iPad Pro (9.7-inch) (C62FCDB3-90B0-4292-95D4-8EE3D1AFA560) (Shutdown) 
    iPad Pro (11-inch) (2nd generation) (F45F9EED-2730-4DC5-8AD7-6029C2567F61) (Shutdown) 
    iPad Pro (12.9-inch) (4th generation) (DD178F70-31BF-450D-ADB7-2E9B8F98F5C6) (Shutdown) 
    iPad (8th generation) (CAE5BC30-89C6-4833-9A2B-2DC16152D355) (Shutdown) 
    iPad Air (4th generation) (F6CE415B-FAF0-4B13-9DB8-002E28BDC143) (Shutdown) 
-- iOS 14.1 --
    iPhone 8 (4AC8D342-B4BA-424F-A08E-A1F7E40613CE) (Shutdown) 
    iPhone 8 Plus (84889CA0-A882-42EB-930D-A9C45DA3AA0E) (Shutdown) 
    iPhone 11 (809710DC-FE30-4C64-9A30-A762D2565885) (Shutdown) 
    iPhone 11 Pro (E1D1606C-9352-48B7-A958-A57243F69940) (Shutdown) 
    iPhone 11 Pro Max (DEBF13F8-ABC1-4261-8DC7-D599B4CDD79B) (Shutdown) 
    iPhone SE (2nd generation) (E197138F-1AEC-4D6A-8161-1BB6122A811B) (Shutdown) 
    iPhone 12 mini (92BBA5AB-33D1-4977-9DD0-10DFE75BE1F5) (Shutdown) 
    iPhone 12 (5912354A-E54B-4F13-B231-DB79236DADFA) (Shutdown) 
    iPhone 12 Pro (EF6B320F-27D2-4308-8B7D-954FA337DB8A) (Shutdown) 
    iPhone 12 Pro Max (6CDE4927-DDCE-469D-AF9F-BBA1DDEE93E5) (Shutdown) 
    iPod touch (7th generation) (869DAEBF-6E3D-4067-A536-2ED03D353FD8) (Shutdown) 
    iPad Pro (9.7-inch) (5B4A2A93-3985-49BD-8E2A-27C40EC6B7A7) (Shutdown) 
    iPad Pro (11-inch) (2nd generation) (C578651F-233F-402E-B3AA-4A386DAE5708) (Shutdown) 
    iPad Pro (12.9-inch) (4th generation) (3D73A2FF-C89B-44C0-B573-CFE2F38815CD) (Shutdown) 
    iPad (8th generation) (C7F04FA7-859E-46EB-817B-6ED34548D73A) (Shutdown) 
    iPad Air (4th generation) (FE90055B-67B0-4477-BA6F-8B28EBC89136) (Shutdown) 
-- tvOS 13.0 --
    Apple TV (C395EA0D-4B92-42CA-8A51-40673CC87FAA) (Shutdown) 
    Apple TV 4K (67535444-3811-4B4B-BB85-D9F20959AD8A) (Shutdown) 
    Apple TV 4K (at 1080p) (B59366E6-806E-4831-8EE1-6BC5FFCE4CDF) (Shutdown) 
-- tvOS 13.2 --
    Apple TV (7EF2CE05-4F18-4C9A-B064-51C50A2D3728) (Shutdown) 
    Apple TV 4K (30574487-A576-4CB9-B36E-F423C541AF2D) (Shutdown) 
    Apple TV 4K (at 1080p) (6A219FB6-DDB6-4F3F-9579-155F7CCFFD91) (Shutdown) 
-- tvOS 13.3 --
    Apple TV (4D95A01E-2835-4B61-9304-ADAD7EABA119) (Shutdown) 
    Apple TV 4K (B3298BDA-743E-4B86-8047-BD48633351F9) (Shutdown) 
    Apple TV 4K (at 1080p) (1B16FDED-A5A6-4381-8909-D676FCA2A93F) (Shutdown) 
-- tvOS 14.0 --
    Apple TV (780C07D6-0667-49AC-9518-9B48A85CAC01) (Shutdown) 
    Apple TV 4K (B0AC31CE-9FBE-4CCB-AF9C-F406C5B48E25) (Shutdown) 
    Apple TV 4K (at 1080p) (A7988151-ABA0-4427-8A38-EFB23C7B8988) (Shutdown) 
-- watchOS 6.0 --
    Apple Watch Series 4 - 40mm (42592BCA-3E7E-488C-8719-7E2850AA8800) (Shutdown) 
    Apple Watch Series 4 - 44mm (DABECCB6-55E7-4001-AA06-88EC29BE01A8) (Shutdown) 
    Apple Watch Series 5 - 40mm (401F9B5A-584C-4EC5-A209-B16911B2807D) (Shutdown) 
    Apple Watch Series 5 - 44mm (F0C96118-D27C-4185-B1AA-7DD1A26CFF3F) (Shutdown) 
-- watchOS 6.1 --
    Apple Watch Series 4 - 40mm (6752C121-BD52-426F-8C20-B3760C10794A) (Shutdown) 
    Apple Watch Series 4 - 44mm (70BC4781-3E03-4F88-ABA5-BB57966524A2) (Shutdown) 
    Apple Watch Series 5 - 40mm (EAF0FACA-5F8D-4DAA-AC03-B0E19176CF01) (Shutdown) 
    Apple Watch Series 5 - 44mm (D7884E10-91C6-47D0-9DC2-B3A43A732F0E) (Shutdown) 
-- watchOS 7.0 --
    Apple Watch Series 5 - 40mm (5AE9ADCF-4B6F-41F5-B6B8-8305927D8BEC) (Shutdown) 
    Apple Watch Series 5 - 44mm (DF9FC1A8-61C7-4560-8A61-359ABEAD423B) (Shutdown) 
    Apple Watch Series 6 - 40mm (28548259-48FF-427C-9AA5-474A554F789D) (Shutdown) 
    Apple Watch Series 6 - 44mm (9173A43F-7DC0-47A3-8761-2C46E17B0083) (Shutdown) 
== Device Pairs ==
F2520D47-05D6-4618-B8A4-A759D904ACB7 (active, disconnected)
    Watch: Apple Watch Series 5 - 40mm (5AE9ADCF-4B6F-41F5-B6B8-8305927D8BEC) (Shutdown)
    Phone: iPhone 12 mini (92BBA5AB-33D1-4977-9DD0-10DFE75BE1F5) (Shutdown)
89E3F8F4-FB6C-4259-93C4-2FFF848B7089 (active, disconnected)
    Watch: Apple Watch Series 5 - 44mm (DF9FC1A8-61C7-4560-8A61-359ABEAD423B) (Shutdown)
    Phone: iPhone 12 (5912354A-E54B-4F13-B231-DB79236DADFA) (Shutdown)
D2FB72D0-45F8-4EA8-A121-D67C0D50017D (active, disconnected)
    Watch: Apple Watch Series 6 - 40mm (28548259-48FF-427C-9AA5-474A554F789D) (Shutdown)
    Phone: iPhone 12 Pro (EF6B320F-27D2-4308-8B7D-954FA337DB8A) (Shutdown)
A2ABB8E8-7251-4AFB-B637-2A92FDCC2BCE (active, disconnected)
    Watch: Apple Watch Series 6 - 44mm (9173A43F-7DC0-47A3-8761-2C46E17B0083) (Shutdown)
    Phone: iPhone 12 Pro Max (6CDE4927-DDCE-469D-AF9F-BBA1DDEE93E5) (Shutdown)
vagrant@prd-atl-elt-g-xcode-12-1-210407231855-WruxS4WMMdN7UWGu5g3di6 ~ %                  
```

### Changes

- I am adding a 3 times retry for device look up so it can found the right device
- I fixed a typo from determin to determine
- I changed var platformAndVersion to osVersion since in line 625 it uses osVersion to show the log but the var wasn't being set, currently it shows this:
```
Simulator infos
* simulator_name: iPhone 8 Plus, version: , UDID: 1CDCD433-93BC-43BA-9E92-C432AA43BAA8, status: Booted
```
With this fix it will log the right version:
```
Simulator infos
* simulator_name: iPhone 8 Plus, version: iOS 14.1, UDID: 1CDCD433-93BC-43BA-9E92-C432AA43BAA8, status: Booted
```
