### PR TITLE
Fix Markdown formatting

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -116,7 +116,7 @@ inputs:
     opts:
       title: Export UITest Artifacts
       description: |-
-        If enabled, the attachments of the UITest will be exported into the BITRISE_DEPLOY_DIR, as a compressed ZIP file.
+        If enabled, the attachments of the UITest will be exported into the `BITRISE_DEPLOY_DIR`, as a compressed ZIP file.
         Attachments include screenshots taken during the UI test, and other artifacts.
 
         __NOTE:__ works only with Xcode version < 11.


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

The underscore in BITRISE_DEPLOY_DIR was interpreted as italics formatting

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
