### PR TITLE
STEP-1054: Use Test Repetition for Xcode 13 and above

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ go/pkg/
 .gows*
 .vscode/
 .idea
+.DS_Store

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -174,7 +174,7 @@ workflows:
     - _check_outputs
     - _check_cache
 
-  test_retry_on_failure:
+  test_retry_succeeds:
     before_run:
     - _expose_xcode_version
     steps:
@@ -185,21 +185,50 @@ workflows:
             set -e
 
             if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode > 10, skipping..."
+              echo "This test case requires Xcode >= 11, skipping..."
               exit 0
             fi
 
-            envman add --key XCODE_MAJOR_VERSION_GREATER_THAN_10 --value "true"
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+            # Number of retries is 2
+            envman add --key TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES --value 1
     - bitrise-run:
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_GREATER_THAN_10" "true"}}'
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
+        inputs:
+        - workflow_id: utility_test_retry_on_failure
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  test_retry_fails:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode >= 11, skipping..."
+              exit 0
+            fi
+
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+            # Number of retries is 2
+            envman add --key TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES --value 3
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
         inputs:
         - workflow_id: utility_test_retry_on_failure
         - bitrise_config_path: ./e2e/bitrise.yml
 
   utility_test_retry_on_failure:
     envs:
-    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
+    # - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_URL: /Users/lpusok/Develop/samples/ios/sample-swift-project-with-parallel-ui-test
+    # - TEST_APP_BRANCH: master
+    - TEST_APP_BRANCH: STEP-1054-test-run-retry
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "FlakyTests"
@@ -208,10 +237,27 @@ workflows:
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
     - SINGLE_BUILD: "true"
     - XCODE_OUTPUT_TOOL: xcodebuild
-    - TEST_RUNNER_FLAKY_TEST_NUMBER_OF_FAILURES: 1
     - RETRY_ON_FAILURE: "yes"
     - EXPECT_TEST_FAILURE: "false"
     - CACHE_LEVEL: "swift_packages"
+    steps:
+    - git::https://github.com/bitrise-steplib/steps-lookup-xcode-simulator:
+        inputs:
+        - simulator_device: $XCODE_SIMULATOR_DEVICE
+        - simulator_os_version: $XCODE_SIMULATOR_OS_VERSION
+        - simulator_platform: $XCODE_SIMULATOR_PLATFORM
+    - script:
+        inputs:
+        - content: |-
+            set -ex
+            xcrun simctl shutdown $XCODE_SIMULATOR_UDID
+            # Reset UserDefaults to clean state
+            xcrun simctl erase $XCODE_SIMULATOR_UDID
+            # simctl boot fails if Simulator already booted, ignore
+            set -x
+            xcrun simctl boot $XCODE_SIMULATOR_UDID
+            set -ex
+            xcrun simctl spawn $XCODE_SIMULATOR_UDID defaults write io.bitrise.BullsEye flaky_test_number_of_failures $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
     after_run:
     - _run
     - _check_outputs

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -190,7 +190,7 @@ workflows:
             fi
 
             envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-            # Number of retries is 2
+            # Number of retries is 1, excepted to succeed
             envman add --key TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES --value 1
     - bitrise-run:
         run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
@@ -214,13 +214,20 @@ workflows:
             fi
 
             envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-            # Number of retries is 2
-            envman add --key TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES --value 3
-    - bitrise-run:
+            # Number of retries is 1, excepted to fail
+            envman add --key TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES --value 2
+    - script:
+        title: Start a failing workflow, wrapped in a script.
         run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
         inputs:
-        - workflow_id: utility_test_retry_on_failure
-        - bitrise_config_path: ./e2e/bitrise.yml
+          - content: |-
+              #!/bin/env bash
+              set -x # Do not set -e as bitrise command is expected to fail
+              bitrise run --config=./e2e/bitrise.yml utility_test_retry_on_failure
+              if [ $? -ne 1 ] ; then
+                echo "Workflow was excepted to fail, exit code not 1."
+                exit 1
+              fi
 
   utility_test_retry_on_failure:
     envs:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -50,7 +50,7 @@ workflows:
         inputs:
         - content: |-
             #!/bin/env bash
-            set -x # Do not set -e as bitrise command is excepted to fail
+            set -x # Do not set -e as bitrise command is expected to fail
             bitrise run --config=./e2e/bitrise.yml utility_objc_failing_ui_test
             if [ $? -ne 1 ] ; then
               echo "Workflow was excepted to fail, exit code not 1."
@@ -174,29 +174,7 @@ workflows:
     - _check_outputs
     - _check_cache
 
-  test_test_repetition:
-    before_run:
-      - _expose_xcode_version
-    steps:
-      - script:
-          inputs:
-            - content: |-
-                #!/bin/env bash
-                set -e
-
-                if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
-                  echo "This test case requires Xcode > 12, skipping..."
-                  exit 0
-                fi
-
-                envman add --key XCODE_MAJOR_VERSION_GREATER_THAN_12 --value "true"
-      - bitrise-run:
-          run_if: '{{enveq "XCODE_MAJOR_VERSION_GREATER_THAN_12" "true"}}'
-          inputs:
-            - workflow_id: utility_test_test_repetition
-            - bitrise_config_path: ./e2e/bitrise.yml
-
-  utility_test_test_repetition:
+  test_retry_on_failure:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
     - TEST_APP_BRANCH: master
@@ -216,6 +194,40 @@ workflows:
     - _run
     - _check_outputs
     - _check_cache
+
+  test_no_retry_on_failure:
+    steps:
+    - script:
+        title: Start a failing workflow, wrapped in a script.
+        inputs:
+          - content: |-
+              #!/bin/env bash
+              set -x # Do not set -e as bitrise command is expected to fail
+              bitrise run --config=./e2e/bitrise.yml utility_test_no_retry_on_failure
+              if [ $? -ne 1 ] ; then
+                echo "Workflow was excepted to fail, exit code not 1."
+                exit 1
+              fi
+
+  utility_test_no_retry_on_failure:
+    envs:
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: master
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "FlakyTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 12
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_RUNNER_FLAKY_TEST_NUMBER_OF_FAILURES: 1
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "true"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _run
+    - _check_outputs
 
   test_simulator_os_version:
     before_run:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -141,15 +141,13 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -e
-
             if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode > 10, skipping..."
+              echo "This test case requires Xcode >= 11, skipping..."
               exit 0
             fi
-
-            envman add --key XCODE_MAJOR_VERSION_GREATER_THAN_10 --value "true"
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
     - bitrise-run:
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_GREATER_THAN_10" "true"}}'
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
         inputs:
         - workflow_id: utility_test_test_plan
         - bitrise_config_path: ./e2e/bitrise.yml
@@ -183,19 +181,15 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -e
-
             if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
               echo "This test case requires Xcode >= 11, skipping..."
               exit 0
             fi
-
             envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-            # Number of retries is 1, excepted to succeed
-            envman add --key TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES --value 1
     - bitrise-run:
         run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
         inputs:
-        - workflow_id: utility_test_retry_on_failure
+        - workflow_id: utility_test_retry_succeeds
         - bitrise_config_path: ./e2e/bitrise.yml
 
   test_retry_fails:
@@ -207,15 +201,11 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -e
-
             if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
               echo "This test case requires Xcode >= 11, skipping..."
               exit 0
             fi
-
             envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-            # Number of retries is 1, excepted to fail
-            envman add --key TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES --value 2
     - script:
         title: Start a failing workflow, wrapped in a script.
         run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
@@ -223,17 +213,16 @@ workflows:
           - content: |-
               #!/bin/env bash
               set -x # Do not set -e as bitrise command is expected to fail
-              bitrise run --config=./e2e/bitrise.yml utility_test_retry_on_failure
+              bitrise run --config=./e2e/bitrise.yml utility_test_retry_fails
               if [ $? -ne 1 ] ; then
                 echo "Workflow was excepted to fail, exit code not 1."
                 exit 1
               fi
 
-  utility_test_retry_on_failure:
+  utility_test_retry_succeeds:
     envs:
-    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
+    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    # - TEST_APP_BRANCH: master
     - TEST_APP_BRANCH: STEP-1054-test-run-retry
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
@@ -246,34 +235,49 @@ workflows:
     - RETRY_ON_FAILURE: "yes"
     - EXPECT_TEST_FAILURE: "false"
     - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_flaky_tests_in_test_app
+    - _run
+    - _check_outputs
+
+  utility_test_retry_fails:
+    envs:
+    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 2
+    - EXPECT_TEST_FAILURE: "true"
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: STEP-1054-test-run-retry
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "FlakyTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - RETRY_ON_FAILURE: "yes"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_flaky_tests_in_test_app
+    - _run
+    - _check_outputs
+
+  test_no_retry_on_failure:
+    before_run:
+    - _expose_xcode_version
     steps:
-    - git::https://github.com/bitrise-steplib/steps-lookup-xcode-simulator:
-        inputs:
-        - simulator_device: $XCODE_SIMULATOR_DEVICE
-        - simulator_os_version: $XCODE_SIMULATOR_OS_VERSION
-        - simulator_platform: $XCODE_SIMULATOR_PLATFORM
     - script:
         inputs:
         - content: |-
-            set -x
-            xcrun simctl shutdown $XCODE_SIMULATOR_UDID
-            # Reset UserDefaults to clean state
-            set -ex
-            xcrun simctl erase $XCODE_SIMULATOR_UDID
-            # simctl boot fails if Simulator already booted, ignore
-            set -x
-            xcrun simctl boot $XCODE_SIMULATOR_UDID
-            set -ex
-            xcrun simctl spawn $XCODE_SIMULATOR_UDID defaults write io.bitrise.BullsEye flaky_test_number_of_failures $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
-    after_run:
-    - _run
-    - _check_outputs
-    - _check_cache
-
-  test_no_retry_on_failure:
-    steps:
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode >= 11, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
     - script:
         title: Start a failing workflow, wrapped in a script.
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
         inputs:
           - content: |-
               #!/bin/env bash
@@ -286,8 +290,10 @@ workflows:
 
   utility_test_no_retry_on_failure:
     envs:
+    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
+    - EXPECT_TEST_FAILURE: "true"
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_BRANCH: STEP-1054-test-run-retry
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "FlakyTests"
@@ -296,11 +302,10 @@ workflows:
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
     - SINGLE_BUILD: "true"
     - XCODE_OUTPUT_TOOL: xcodebuild
-    - TEST_RUNNER_FLAKY_TEST_NUMBER_OF_FAILURES: 1
     - RETRY_ON_FAILURE: "no"
-    - EXPECT_TEST_FAILURE: "true"
     - CACHE_LEVEL: "swift_packages"
     after_run:
+    - _set_number_of_flaky_tests_in_test_app
     - _run
     - _check_outputs
 
@@ -345,6 +350,38 @@ workflows:
     - _run
     - _check_outputs
 
+  _set_number_of_flaky_tests_in_test_app:
+    envs:
+      - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
+      - XCODE_SIMULATOR_DEVICE: $XCODE_SIMULATOR_DEVICE
+      - XCODE_SIMULATOR_OS_VERSION: $XCODE_SIMULATOR_OS_VERSION
+      - XCODE_SIMULATOR_PLATFORM: $XCODE_SIMULATOR_PLATFORM
+    steps:
+    - git::https://github.com/bitrise-steplib/steps-lookup-xcode-simulator:
+        inputs:
+        - simulator_device: $XCODE_SIMULATOR_DEVICE
+        - simulator_os_version: $XCODE_SIMULATOR_OS_VERSION
+        - simulator_platform: $XCODE_SIMULATOR_PLATFORM
+    - script:
+        title: Set number of flaky test failures on the Simulator for the app io.bitrise.BullsEye
+        inputs:
+        - content: |-
+            set -ex
+            if [[ -x $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES ]]; then
+              echo "Variable TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES is unset"
+              exit 1
+            fi
+            set -x
+            xcrun simctl shutdown $XCODE_SIMULATOR_UDID
+            # Reset UserDefaults to clean state
+            set -ex
+            xcrun simctl erase $XCODE_SIMULATOR_UDID
+            # simctl boot fails if Simulator already booted, ignore
+            set -x
+            xcrun simctl boot $XCODE_SIMULATOR_UDID
+            set -ex
+            xcrun simctl spawn $XCODE_SIMULATOR_UDID defaults write io.bitrise.BullsEye flaky_test_number_of_failures $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
+
   _run:
     before_run:
     - _clear_outputs
@@ -361,6 +398,17 @@ workflows:
           - clone_into_dir: ./_tmp
           - branch: $TEST_APP_BRANCH
     - certificate-and-profile-installer: {}
+    - script:
+        title: Set 'collect_simulator_diagnostics' input
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -ex
+            COLLECT_SIM_DIAGNOSTICS="on_failure"
+            if [[ "$EXPECT_TEST_FAILURE" == "true" ]]; then
+              COLLECT_SIM_DIAGNOSTICS="never"
+            fi
+            envman add --key COLLECT_SIM_DIAGNOSTICS --value $COLLECT_SIM_DIAGNOSTICS
     - path::./:
         inputs:
         - project_path: ./_tmp/$BITRISE_PROJECT_PATH
@@ -377,7 +425,7 @@ workflows:
         - verbose: "yes"
         - should_retry_test_on_fail: $RETRY_ON_FAILURE
         - cache_level: $CACHE_LEVEL
-        - collect_simulator_diagnostics: on_failure
+        - collect_simulator_diagnostics: $COLLECT_SIM_DIAGNOSTICS
 
   _expose_xcode_version:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -174,6 +174,49 @@ workflows:
     - _check_outputs
     - _check_cache
 
+  test_test_repetition:
+    before_run:
+      - _expose_xcode_version
+    steps:
+      - script:
+          inputs:
+            - content: |-
+                #!/bin/env bash
+                set -e
+
+                if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+                  echo "This test case requires Xcode > 12, skipping..."
+                  exit 0
+                fi
+
+                envman add --key XCODE_MAJOR_VERSION_GREATER_THAN_12 --value "true"
+      - bitrise-run:
+          run_if: '{{enveq "XCODE_MAJOR_VERSION_GREATER_THAN_12" "true"}}'
+          inputs:
+            - workflow_id: utility_test_test_repetition
+            - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_test_repetition:
+    envs:
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: master
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "FlakyTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 12
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_RUNNER_FLAKY_TEST_NUMBER_OF_FAILURES: 1
+    - RETRY_ON_FAILURE: "yes"
+    - EXPECT_TEST_FAILURE: "false"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _run
+    - _check_outputs
+    - _check_cache
+
   test_simulator_os_version:
     before_run:
     - _expose_xcode_version

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -371,15 +371,15 @@ workflows:
               echo "Variable TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES is unset"
               exit 1
             fi
-            set -x
+            set +e
             xcrun simctl shutdown $XCODE_SIMULATOR_UDID
             # Reset UserDefaults to clean state
-            set -ex
+            set -e
             xcrun simctl erase $XCODE_SIMULATOR_UDID
             # simctl boot fails if Simulator already booted, ignore
-            set -x
+            set +e
             xcrun simctl boot $XCODE_SIMULATOR_UDID
-            set -ex
+            set -e
             xcrun simctl spawn $XCODE_SIMULATOR_UDID defaults write io.bitrise.BullsEye flaky_test_number_of_failures $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
 
   _run:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -256,9 +256,10 @@ workflows:
     - script:
         inputs:
         - content: |-
-            set -ex
+            set -x
             xcrun simctl shutdown $XCODE_SIMULATOR_UDID
             # Reset UserDefaults to clean state
+            set -ex
             xcrun simctl erase $XCODE_SIMULATOR_UDID
             # simctl boot fails if Simulator already booted, ignore
             set -x

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -181,7 +181,7 @@ workflows:
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "FlakyTests"
-    - XCODE_SIMULATOR_DEVICE: iPhone 12
+    - XCODE_SIMULATOR_DEVICE: iPhone 8
     - XCODE_SIMULATOR_OS_VERSION: "latest"
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
     - SINGLE_BUILD: "true"

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -175,6 +175,28 @@ workflows:
     - _check_cache
 
   test_retry_on_failure:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode > 10, skipping..."
+              exit 0
+            fi
+
+            envman add --key XCODE_MAJOR_VERSION_GREATER_THAN_10 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_GREATER_THAN_10" "true"}}'
+        inputs:
+        - workflow_id: utility_test_retry_on_failure
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_retry_on_failure:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
     - TEST_APP_BRANCH: master

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -232,14 +232,13 @@ workflows:
   utility_test_retry_on_failure:
     envs:
     - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
-    # - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_URL: /Users/lpusok/Develop/samples/ios/sample-swift-project-with-parallel-ui-test
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
     # - TEST_APP_BRANCH: master
     - TEST_APP_BRANCH: STEP-1054-test-run-retry
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "FlakyTests"
-    - XCODE_SIMULATOR_DEVICE: iPhone 8
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
     - XCODE_SIMULATOR_OS_VERSION: "latest"
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
     - SINGLE_BUILD: "true"

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -223,7 +223,7 @@ workflows:
     envs:
     - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1054-test-run-retry
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "FlakyTests"
@@ -245,7 +245,7 @@ workflows:
     - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 2
     - EXPECT_TEST_FAILURE: "true"
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1054-test-run-retry
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "FlakyTests"
@@ -293,7 +293,7 @@ workflows:
     - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
     - EXPECT_TEST_FAILURE: "true"
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1054-test-run-retry
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "FlakyTests"

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ const (
 	timedOutRegisteringForTestingEvent       = `Timed out registering for testing event accessibility notifications`
 )
 
-var automaticRetryReasonPatterns = []string{
+var testRunnerErrorPatterns = []string{
 	timeOutMessageIPhoneSimulator,
 	timeOutMessageUITest,
 	earlyUnexpectedExit,
@@ -397,7 +397,15 @@ func (s Step) Run(cfg Config) (Result, error) {
 		}
 	}
 
-	testLog, exitCode, testErr := runTest(testParams, cfg.OutputTool, cfg.XcprettyOptions, true, cfg.ShouldRetryTestOnFail, swiftPackagesPath)
+	params := testRunParams{
+		buildTestParams:              testParams,
+		outputTool:                   cfg.OutputTool,
+		xcprettyOptions:              cfg.XcprettyOptions,
+		retryOnTestRunnerError:       true,
+		retryOnTestOrTestRunnerError: cfg.ShouldRetryTestOnFail,
+		swiftPackagesPath:            swiftPackagesPath,
+	}
+	testLog, exitCode, testErr := runTest(params)
 	result.XcresultPath = xcresultPath
 	result.XcodebuildTestLog = testLog
 

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ const (
 	appAccessibilityIsNotLoaded              = `UI Testing Failure - App accessibility isn't loaded`
 	testRunnerFailedToInitializeForUITesting = `Test runner failed to initialize for UI testing`
 	timedOutRegisteringForTestingEvent       = `Timed out registering for testing event accessibility notifications`
+	testRunnerNeverBeganExecuting            = `Test runner never began executing tests after launching.`
 )
 
 var testRunnerErrorPatterns = []string{
@@ -55,6 +56,7 @@ var testRunnerErrorPatterns = []string{
 	appAccessibilityIsNotLoaded,
 	testRunnerFailedToInitializeForUITesting,
 	timedOutRegisteringForTestingEvent,
+	testRunnerNeverBeganExecuting,
 }
 
 const simulatorShutdownState = "Shutdown"

--- a/main.go
+++ b/main.go
@@ -399,12 +399,13 @@ func (s Step) Run(cfg Config) (Result, error) {
 	}
 
 	params := testRunParams{
-		buildTestParams:        testParams,
-		outputTool:             cfg.OutputTool,
-		xcprettyOptions:        cfg.XcprettyOptions,
-		retryOnTestRunnerError: true,
-		swiftPackagesPath:      swiftPackagesPath,
-		xcodeMajorVersion:      cfg.XcodeMajorVersion,
+		buildTestParams:                    testParams,
+		outputTool:                         cfg.OutputTool,
+		xcprettyOptions:                    cfg.XcprettyOptions,
+		retryOnTestRunnerError:             true,
+		retryOnSwiftPackageResolutionError: true,
+		swiftPackagesPath:                  swiftPackagesPath,
+		xcodeMajorVersion:                  cfg.XcodeMajorVersion,
 	}
 	testLog, exitCode, testErr := runTest(params)
 	result.XcresultPath = xcresultPath

--- a/main.go
+++ b/main.go
@@ -156,13 +156,17 @@ func (s Step) ProcessConfig() (Config, error) {
 	// validate Xcode version
 	xcodebuildVersion, err := utility.GetXcodeVersion()
 	if err != nil {
-		return Config{}, fmt.Errorf("failed to determine xcode version, error: %s", err)
+		return Config{}, fmt.Errorf("failed to determine Xcode version, error: %s", err)
 	}
 	log.Printf("- xcodebuildVersion: %s (%s)", xcodebuildVersion.Version, xcodebuildVersion.BuildVersion)
 
 	xcodeMajorVersion := xcodebuildVersion.MajorVersion
 	if xcodeMajorVersion < minSupportedXcodeMajorVersion {
-		return Config{}, fmt.Errorf("invalid xcode major version (%d), should not be less then min supported: %d", xcodeMajorVersion, minSupportedXcodeMajorVersion)
+		return Config{}, fmt.Errorf("invalid Xcode major version (%d), should not be less then min supported: %d", xcodeMajorVersion, minSupportedXcodeMajorVersion)
+	}
+
+	if xcodeMajorVersion < 11 && input.TestPlan != "" {
+		return Config{}, fmt.Errorf("input Test Plan incompatible with Xcode %d, at least Xcode 11 required", xcodeMajorVersion)
 	}
 
 	// validate headless mode

--- a/main.go
+++ b/main.go
@@ -380,8 +380,9 @@ func (s Step) Run(cfg Config) (Result, error) {
 		TestPlan:             cfg.TestPlan,
 		TestOutputDir:        xcresultPath,
 		BuildBeforeTest:      cfg.BuildBeforeTesting,
-		AdditionalOptions:    cfg.XcodebuildTestoptions,
 		GenerateCodeCoverage: cfg.GenerateCodeCoverageFiles,
+		RetryTestsOnFailure:  cfg.ShouldRetryTestOnFail,
+		AdditionalOptions:    cfg.XcodebuildTestoptions,
 	}
 
 	if cfg.IsSingleBuild {
@@ -398,12 +399,12 @@ func (s Step) Run(cfg Config) (Result, error) {
 	}
 
 	params := testRunParams{
-		buildTestParams:              testParams,
-		outputTool:                   cfg.OutputTool,
-		xcprettyOptions:              cfg.XcprettyOptions,
-		retryOnTestRunnerError:       true,
-		retryOnTestOrTestRunnerError: cfg.ShouldRetryTestOnFail,
-		swiftPackagesPath:            swiftPackagesPath,
+		buildTestParams:        testParams,
+		outputTool:             cfg.OutputTool,
+		xcprettyOptions:        cfg.XcprettyOptions,
+		retryOnTestRunnerError: true,
+		swiftPackagesPath:      swiftPackagesPath,
+		xcodeMajorVersion:      cfg.XcodeMajorVersion,
 	}
 	testLog, exitCode, testErr := runTest(params)
 	result.XcresultPath = xcresultPath

--- a/models/models.go
+++ b/models/models.go
@@ -12,12 +12,12 @@ type XcodeBuildParamsModel struct {
 
 // XcodeBuildTestParamsModel ...
 type XcodeBuildTestParamsModel struct {
-	BuildParams XcodeBuildParamsModel
-	TestPlan    string
-
+	BuildParams          XcodeBuildParamsModel
+	TestPlan             string
 	TestOutputDir        string
 	CleanBuild           bool
 	BuildBeforeTest      bool
 	GenerateCodeCoverage bool
+	RetryTestsOnFailure  bool
 	AdditionalOptions    string
 }

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -237,7 +237,7 @@ func createXcodebuildTestArgs(params models.XcodeBuildTestParamsModel, xcodeMajo
 		xcodebuildArgs = append(xcodebuildArgs, "-retry-tests-on-failure")
 
 		// TODO(STEP-1054): Allow customization of `-test-iterations`.
-		xcodebuildArgs = append(xcodebuildArgs, "-test-iterations 2")
+		xcodebuildArgs = append(xcodebuildArgs, "-test-iterations", "2")
 	}
 
 	if params.AdditionalOptions != "" {


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context
* Xcode 13 supports Test Repetition to retry failing tests.
* This feature is already supported by the Xcode Test step. However, that reruns ALL tests, not just the ones that failed.

### Changes
**Use Xcode 13's Test Repetition feature if "Should retry test on failure?" is enabled.**
* This only works on Xcode 13+ stacks.
* Below Xcode 13, we keep using our own custom logic that reruns all tests in case of failure.
* Added E2E tests for this option (both enabled and disabled).
* Brokedown `runTest` function into smaller functions; extracted long parameter lists into structs.
