### PR TITLE
Fix xcodebuild test output log filename.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -112,7 +112,7 @@ func printLastLinesOfXcodebuildTestLog(rawXcodebuildOutput string, isRunSuccess 
 	fmt.Println(stringutil.LastNLines(rawXcodebuildOutput, 20))
 
 	if !isRunSuccess {
-		log.Warnf("If you can't find the reason of the error in the log, please check the raw-xcodebuild-output.log.")
+		log.Warnf("If you can't find the reason of the error in the log, please check the xcodebuild_test.log.")
 	}
 
 	log.Infof(colorstring.Magenta(`


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

xcodebuild test command log is stored in `xcodebuild_test.log` file, but the step log was not updated:

```
If you can't find the reason of the error in the log, please check the raw-xcodebuild-output.log.
```

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

- Fix xcodebuild test output log filename (`raw-xcodebuild-output.log` -> `xcodebuild_test.log`).

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
