### PR TITLE
STEP-1201: Add Test Repetition Mode step input

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -184,40 +184,16 @@ workflows:
             if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
               echo "This test case requires Xcode >= 11, skipping..."
               exit 0
+            elif [[ $XCODE_MAJOR_VERSION -gt 12 ]]; then
+              echo "This test case requires Xcode <= 12, skipping..."
+              exit 0
             fi
-            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+            envman add --key XCODE_MAJOR_VERSION_BETWEEN_11_AND_12 --value "true"
     - bitrise-run:
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_BETWEEN_11_AND_12" "true"}}'
         inputs:
         - workflow_id: utility_test_retry_succeeds
         - bitrise_config_path: ./e2e/bitrise.yml
-
-  test_retry_fails:
-    before_run:
-    - _expose_xcode_version
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/env bash
-            set -e
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode >= 11, skipping..."
-              exit 0
-            fi
-            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-    - script:
-        title: Start a failing workflow, wrapped in a script.
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
-        inputs:
-          - content: |-
-              #!/bin/env bash
-              set -x # Do not set -e as bitrise command is expected to fail
-              bitrise run --config=./e2e/bitrise.yml utility_test_retry_fails
-              if [ $? -ne 1 ] ; then
-                echo "Workflow was excepted to fail, exit code not 1."
-                exit 1
-              fi
 
   utility_test_retry_succeeds:
     envs:
@@ -239,6 +215,36 @@ workflows:
     - _set_number_of_flaky_tests_in_test_app
     - _run
     - _check_outputs
+
+  test_retry_fails:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode >= 11, skipping..."
+              exit 0
+            elif [[ $XCODE_MAJOR_VERSION -gt 12 ]]; then
+              echo "This test case requires Xcode <= 12, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_BETWEEN_11_AND_12 --value "true"
+    - script:
+        title: Start a failing workflow, wrapped in a script.
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_BETWEEN_11_AND_12" "true"}}'
+        inputs:
+          - content: |-
+              #!/bin/env bash
+              set -x # Do not set -e as bitrise command is expected to fail
+              bitrise run --config=./e2e/bitrise.yml utility_test_retry_fails
+              if [ $? -ne 1 ] ; then
+                echo "Workflow was expected to fail, exit code not 1."
+                exit 1
+              fi
 
   utility_test_retry_fails:
     envs:
@@ -273,11 +279,14 @@ workflows:
             if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
               echo "This test case requires Xcode >= 11, skipping..."
               exit 0
+            elif [[ $XCODE_MAJOR_VERSION -gt 12 ]]; then
+              echo "This test case requires Xcode <= 12, skipping..."
+              exit 0
             fi
-            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+            envman add --key XCODE_MAJOR_VERSION_BETWEEN_11_AND_12 --value "true"
     - script:
         title: Start a failing workflow, wrapped in a script.
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_BETWEEN_11_AND_12" "true"}}'
         inputs:
           - content: |-
               #!/bin/env bash

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -95,9 +95,7 @@ workflows:
             envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
 
             device="iPad Air (4th generation)"
-            if [[ ${XCODE_MAJOR_VERSION} -eq 10 ]]; then
-              device="iPad Air (3rd generation)"
-            elif [[ ${XCODE_MAJOR_VERSION} -eq 11 ]]; then
+            if [[ ${XCODE_MAJOR_VERSION} -eq 11 ]]; then
               device="iPad Air (3rd generation)"
             elif [[ ${XCODE_MAJOR_VERSION} -eq 12 ]]; then
               device="iPad Air (4th generation)"
@@ -505,12 +503,19 @@ workflows:
               COLLECT_SIM_DIAGNOSTICS="never"
             fi
             envman add --key COLLECT_SIM_DIAGNOSTICS --value $COLLECT_SIM_DIAGNOSTICS
+    - script:
+        title: Set TEST_REPETITION_MODE to 'none' if not set
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -eo pipefail
+            export TEST_REPETITION_MODE=${TEST_REPETITION_MODE-none}
     - path::./:
         inputs:
         - project_path: ./_tmp/$BITRISE_PROJECT_PATH
         - scheme: $BITRISE_SCHEME
         - test_plan: $TEST_PLAN
-        - test_repetition_mode: ${TEST_REPETITION_MODE-none}
+        - test_repetition_mode: $TEST_REPETITION_MODE
         - simulator_device: $XCODE_SIMULATOR_DEVICE
         - simulator_os_version: $XCODE_SIMULATOR_OS_VERSION
         - simulator_platform: $XCODE_SIMULATOR_PLATFORM

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -509,7 +509,7 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -eo pipefail
-            export TEST_REPETITION_MODE=${TEST_REPETITION_MODE-none}
+            envman add --key TEST_REPETITION_MODE --value ${TEST_REPETITION_MODE-none}
     - path::./:
         inputs:
         - project_path: ./_tmp/$BITRISE_PROJECT_PATH

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -195,7 +195,7 @@ workflows:
             set -x # Do not set -e as bitrise command is expected to fail
             bitrise run --config=./e2e/bitrise.yml utility_test_retry_on_failure_not_available_above_xcode_13
             if [ $? -ne 1 ] ; then
-              echo "Workflow was excepted to fail, exit code not 1."
+              echo "Workflow was expected to fail, exit code not 1."
               exit 1
             fi
 
@@ -214,7 +214,6 @@ workflows:
     - CACHE_LEVEL: "swift_packages"
     after_run:
     - _run
-    - _check_outputs
 
   test_repetition_mode_not_available_below_xcode_13:
     before_run:
@@ -239,7 +238,7 @@ workflows:
             set -x # Do not set -e as bitrise command is expected to fail
             bitrise run --config=./e2e/bitrise.yml utility_test_repetition_mode_not_available_below_xcode_13
             if [ $? -ne 1 ] ; then
-              echo "Workflow was excepted to fail, exit code not 1."
+              echo "Workflow was expected to fail, exit code not 1."
               exit 1
             fi
 
@@ -254,11 +253,11 @@ workflows:
       - XCODE_SIMULATOR_PLATFORM: iOS Simulator
       - SINGLE_BUILD: "true"
       - XCODE_OUTPUT_TOOL: xcodebuild
-      - RETRY_ON_FAILURE: "yes"
+      - RETRY_ON_FAILURE: "no"
+      - TEST_REPETITION_MODE: "retry_on_failure"
       - CACHE_LEVEL: "swift_packages"
     after_run:
     - _run
-    - _check_outputs
 
   test_retry_succeeds:
     before_run:
@@ -381,7 +380,7 @@ workflows:
               set -x # Do not set -e as bitrise command is expected to fail
               bitrise run --config=./e2e/bitrise.yml utility_test_no_retry_on_failure
               if [ $? -ne 1 ] ; then
-                echo "Workflow was excepted to fail, exit code not 1."
+                echo "Workflow was expected to fail, exit code not 1."
                 exit 1
               fi
 
@@ -511,6 +510,7 @@ workflows:
         - project_path: ./_tmp/$BITRISE_PROJECT_PATH
         - scheme: $BITRISE_SCHEME
         - test_plan: $TEST_PLAN
+        - test_repetition_mode: ${TEST_REPETITION_MODE-none}
         - simulator_device: $XCODE_SIMULATOR_DEVICE
         - simulator_os_version: $XCODE_SIMULATOR_OS_VERSION
         - simulator_platform: $XCODE_SIMULATOR_PLATFORM

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -88,11 +88,11 @@ workflows:
             set -e
 
             if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode > 10, skipping..."
+              echo "This test case requires Xcode >= 11, skipping..."
               exit 0
             fi
 
-            envman add --key XCODE_MAJOR_VERSION_GREATER_THAN_10 --value "true"
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
 
             device="iPad Air (4th generation)"
             if [[ ${XCODE_MAJOR_VERSION} -eq 10 ]]; then
@@ -108,7 +108,7 @@ workflows:
             echo "Xcode version based iPad device: $device"
             envman add --key XCODE_SIMULATOR_DEVICE --value "$device"
     - bitrise-run:
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_GREATER_THAN_10" "true"}}'
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
         inputs:
         - workflow_id: utility_test_parallel
         - bitrise_config_path: ./e2e/bitrise.yml

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -172,6 +172,94 @@ workflows:
     - _check_outputs
     - _check_cache
 
+  test_retry_on_failure_not_available_above_xcode_13:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - script:
+        title: Start a failing workflow, wrapped in a script.
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_retry_on_failure_not_available_above_xcode_13
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was excepted to fail, exit code not 1."
+              exit 1
+            fi
+
+  utility_test_retry_on_failure_not_available_above_xcode_13:
+    envs:
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: master
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - RETRY_ON_FAILURE: "yes"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _run
+    - _check_outputs
+
+  test_repetition_mode_not_available_below_xcode_13:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -gt 12 ]]; then
+              echo "This test case requires Xcode <= 12, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_MOST_12 --value "true"
+    - script:
+        title: Start a failing workflow, wrapped in a script.
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_MOST_12" "true"}}'
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_repetition_mode_not_available_below_xcode_13
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was excepted to fail, exit code not 1."
+              exit 1
+            fi
+
+  utility_test_repetition_mode_not_available_below_xcode_13:
+    envs:
+      - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+      - TEST_APP_BRANCH: master
+      - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+      - BITRISE_SCHEME: BullsEye
+      - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+      - XCODE_SIMULATOR_OS_VERSION: "latest"
+      - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+      - SINGLE_BUILD: "true"
+      - XCODE_OUTPUT_TOOL: xcodebuild
+      - RETRY_ON_FAILURE: "yes"
+      - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _run
+    - _check_outputs
+
   test_retry_succeeds:
     before_run:
     - _expose_xcode_version

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ type Input struct {
 	IsSingleBuild         bool   `env:"single_build,opt[true,false]"`
 	ShouldBuildBeforeTest bool   `env:"should_build_before_test,opt[yes,no]"`
 
-	ShouldRetryTestOnFail     bool `env:"should_retry_test_on_fail,opt[yes,no]"`
+	RetryTestsOnFailure       bool `env:"should_retry_test_on_fail,opt[yes,no]"`
 	DisableIndexWhileBuilding bool `env:"disable_index_while_building,opt[yes,no]"`
 	GenerateCodeCoverageFiles bool `env:"generate_code_coverage_files,opt[yes,no]"`
 	HeadlessMode              bool `env:"headless_mode,opt[yes,no]"`
@@ -128,7 +128,7 @@ type Config struct {
 	IsSingleBuild      bool
 	BuildBeforeTesting bool
 
-	ShouldRetryTestOnFail     bool
+	RetryTestsOnFailure       bool
 	DisableIndexWhileBuilding bool
 	GenerateCodeCoverageFiles bool
 	HeadlessMode              bool
@@ -265,7 +265,7 @@ func (s Step) ProcessConfig() (Config, error) {
 		IsSingleBuild:      input.IsSingleBuild,
 		BuildBeforeTesting: input.ShouldBuildBeforeTest,
 
-		ShouldRetryTestOnFail:     input.ShouldRetryTestOnFail,
+		RetryTestsOnFailure:       input.RetryTestsOnFailure,
 		DisableIndexWhileBuilding: input.DisableIndexWhileBuilding,
 		GenerateCodeCoverageFiles: input.GenerateCodeCoverageFiles,
 		HeadlessMode:              headlessMode,
@@ -387,7 +387,7 @@ func (s Step) Run(cfg Config) (Result, error) {
 		TestOutputDir:        xcresultPath,
 		BuildBeforeTest:      cfg.BuildBeforeTesting,
 		GenerateCodeCoverage: cfg.GenerateCodeCoverageFiles,
-		RetryTestsOnFailure:  cfg.ShouldRetryTestOnFail,
+		RetryTestsOnFailure:  cfg.RetryTestsOnFailure,
 		AdditionalOptions:    cfg.XcodebuildTestoptions,
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -255,6 +256,14 @@ func (s Step) ProcessConfig() (Config, error) {
 
 	log.Printf("* device_destination: %s", deviceDestination)
 	fmt.Println()
+
+	if input.TestRepetitionMode != none && xcodeMajorVersion < 13 {
+		return Config{}, errors.New("test_repetition_mode is not supported below Xcode 13")
+	}
+
+	if input.RetryTestsOnFailure && xcodeMajorVersion > 12 {
+		return Config{}, errors.New("should_retry_test_on_fail is not supported above Xcode 12")
+	}
 
 	return Config{
 		ProjectPath: projectPath,

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ var testRunnerErrorPatterns = []string{
 const simulatorShutdownState = "Shutdown"
 
 const (
-	xcodeBuildTool = "xcodebuild"
+	xcodebuildTool = "xcodebuild"
 	xcprettyTool   = "xcpretty"
 )
 
@@ -417,7 +417,7 @@ func (s Step) Run(cfg Config) (Result, error) {
 	result.XcresultPath = xcresultPath
 	result.XcodebuildTestLog = testLog
 
-	if testErr != nil || cfg.OutputTool == xcodeBuildTool {
+	if testErr != nil || cfg.OutputTool == xcodebuildTool {
 		printLastLinesOfXcodebuildTestLog(testLog, testErr == nil)
 	}
 
@@ -588,7 +588,7 @@ func run() error {
 	}
 
 	if err := step.InstallDeps(config.OutputTool == xcprettyTool); err != nil {
-		config.OutputTool = xcodeBuildTool
+		config.OutputTool = xcodebuildTool
 	}
 
 	res, runErr := step.Run(config)

--- a/main.go
+++ b/main.go
@@ -258,11 +258,11 @@ func (s Step) ProcessConfig() (Config, error) {
 	fmt.Println()
 
 	if input.TestRepetitionMode != none && xcodeMajorVersion < 13 {
-		return Config{}, errors.New("test_repetition_mode is not supported below Xcode 13")
+		return Config{}, errors.New("Test Repetition Mode (test_repetition_mode) is not available below Xcode 13")
 	}
 
 	if input.RetryTestsOnFailure && xcodeMajorVersion > 12 {
-		return Config{}, errors.New("should_retry_test_on_fail is not supported above Xcode 12; use test_repetition_mode=retry_on_failure instead")
+		return Config{}, errors.New("Should retry test on failure? (should_retry_test_on_fail) is not available above Xcode 12; use test_repetition_mode=retry_on_failure instead")
 	}
 
 	return Config{

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ type Config struct {
 	GenerateCodeCoverageFiles bool
 	HeadlessMode              bool
 
-	XcodebuildTestoptions string
+	XcodebuildTestOptions string
 	XcprettyOptions       string
 
 	Verbose        bool
@@ -270,7 +270,7 @@ func (s Step) ProcessConfig() (Config, error) {
 		GenerateCodeCoverageFiles: input.GenerateCodeCoverageFiles,
 		HeadlessMode:              headlessMode,
 
-		XcodebuildTestoptions: input.TestOptions,
+		XcodebuildTestOptions: input.TestOptions,
 		XcprettyOptions:       input.XcprettyTestOptions,
 
 		Verbose:        input.Verbose,
@@ -388,7 +388,7 @@ func (s Step) Run(cfg Config) (Result, error) {
 		BuildBeforeTest:      cfg.BuildBeforeTesting,
 		GenerateCodeCoverage: cfg.GenerateCodeCoverageFiles,
 		RetryTestsOnFailure:  cfg.RetryTestsOnFailure,
-		AdditionalOptions:    cfg.XcodebuildTestoptions,
+		AdditionalOptions:    cfg.XcodebuildTestOptions,
 	}
 
 	if cfg.IsSingleBuild {

--- a/main.go
+++ b/main.go
@@ -88,6 +88,9 @@ type Input struct {
 	SimulatorDevice    string `env:"simulator_device,required"`
 	SimulatorOsVersion string `env:"simulator_os_version,required"`
 
+	// Test Repetition
+	TestRepetitionMode string `env:"test_repetition_mode,opt[none,until_failure,retry_on_failure,up_until_maximum_repetitions]"`
+
 	// Test Run Configs
 	OutputTool            string `env:"output_tool,opt[xcpretty,xcodebuild]"`
 	IsCleanBuild          bool   `env:"is_clean_build,opt[yes,no]"`
@@ -122,6 +125,8 @@ type Config struct {
 	XcodeMajorVersion int
 	SimulatorID       string
 	IsSimulatorBooted bool
+
+	TestRepetitionMode string
 
 	OutputTool         string
 	IsCleanBuild       bool
@@ -260,6 +265,8 @@ func (s Step) ProcessConfig() (Config, error) {
 		SimulatorID:       sim.ID,
 		IsSimulatorBooted: sim.Status != simulatorShutdownState,
 
+		TestRepetitionMode: input.TestRepetitionMode,
+
 		OutputTool:         input.OutputTool,
 		IsCleanBuild:       input.IsCleanBuild,
 		IsSingleBuild:      input.IsSingleBuild,
@@ -385,6 +392,7 @@ func (s Step) Run(cfg Config) (Result, error) {
 		BuildParams:          buildParams,
 		TestPlan:             cfg.TestPlan,
 		TestOutputDir:        xcresultPath,
+		TestRepetitionMode:   cfg.TestRepetitionMode,
 		BuildBeforeTest:      cfg.BuildBeforeTesting,
 		GenerateCodeCoverage: cfg.GenerateCodeCoverageFiles,
 		RetryTestsOnFailure:  cfg.RetryTestsOnFailure,

--- a/main.go
+++ b/main.go
@@ -262,7 +262,7 @@ func (s Step) ProcessConfig() (Config, error) {
 	}
 
 	if input.RetryTestsOnFailure && xcodeMajorVersion > 12 {
-		return Config{}, errors.New("should_retry_test_on_fail is not supported above Xcode 12")
+		return Config{}, errors.New("should_retry_test_on_fail is not supported above Xcode 12; use test_repetition_mode=retry_on_failure instead")
 	}
 
 	return Config{

--- a/main.go
+++ b/main.go
@@ -354,7 +354,7 @@ func (s Step) Run(cfg Config) (Result, error) {
 		projectFlag = "-workspace"
 	}
 
-	buildParams := models.XcodeBuildParamsModel{
+	buildParams := models.XcodebuildParams{
 		Action:                    projectFlag,
 		ProjectPath:               cfg.ProjectPath,
 		Scheme:                    cfg.Scheme,
@@ -381,7 +381,7 @@ func (s Step) Run(cfg Config) (Result, error) {
 	}
 	xcresultPath := path.Join(tempDir, "Test.xcresult")
 
-	testParams := models.XcodeBuildTestParamsModel{
+	testParams := models.XcodebuildTestParams{
 		BuildParams:          buildParams,
 		TestPlan:             cfg.TestPlan,
 		TestOutputDir:        xcresultPath,

--- a/main_test.go
+++ b/main_test.go
@@ -460,7 +460,7 @@ func Test_GivenXcprettyDetermineVersionError_WhenTheErrorIsHandled_ThenExpectThe
 	outputTool, err := handleXcprettyInstallError(givenError)
 
 	// Then
-	assert.Equal(t, xcodeBuildTool, outputTool)
+	assert.Equal(t, xcodebuildTool, outputTool)
 	assert.NoError(t, err)
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -15,6 +15,7 @@ type XcodebuildTestParams struct {
 	BuildParams          XcodebuildParams
 	TestPlan             string
 	TestOutputDir        string
+	TestRepetitionMode   string
 	CleanBuild           bool
 	BuildBeforeTest      bool
 	GenerateCodeCoverage bool

--- a/models/models.go
+++ b/models/models.go
@@ -1,7 +1,7 @@
 package models
 
-// XcodeBuildParamsModel ...
-type XcodeBuildParamsModel struct {
+// XcodebuildParams ...
+type XcodebuildParams struct {
 	Action                    string
 	ProjectPath               string
 	Scheme                    string
@@ -10,9 +10,9 @@ type XcodeBuildParamsModel struct {
 	DisableIndexWhileBuilding bool
 }
 
-// XcodeBuildTestParamsModel ...
-type XcodeBuildTestParamsModel struct {
-	BuildParams          XcodeBuildParamsModel
+// XcodebuildTestParams ...
+type XcodebuildTestParams struct {
+	BuildParams          XcodebuildParams
 	TestPlan             string
 	TestOutputDir        string
 	CleanBuild           bool

--- a/step.yml
+++ b/step.yml
@@ -161,6 +161,24 @@ inputs:
         - "yes"
         - "no"
       is_required: true
+  - test_repetition_mode: "none"
+    opts:
+      title: Test Repetition Mode
+      category: Test Repetition
+      summary: Determines how the tests will repeat.
+      description: |-
+        Determines how the tests will repeat.
+
+        Available options:
+        - `none`: Tests will never repeat.
+        - `until_failure`: Tests will repeat until failure or up to maximum repetitions.
+        - `retry_on_failure`: Only failed tests will repeat up to maximum repetitions.
+        - `up_until_maximum_repetitions`: Tests will repeat up until maximum repetitions.
+      value_options:
+        - "none"
+        - "until_failure"
+        - "retry_on_failure"
+        - "up_until_maximum_repetitions"
   - verbose: "no"
     opts:
       category: Debug

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -248,11 +248,9 @@ func createXcodebuildTestArgs(params models.XcodebuildTestParams, xcodeMajorVers
 		xcodebuildArgs = append(xcodebuildArgs, "-retry-tests-on-failure")
 	case upUntilMaximumRepetitions, none:
 		break
-	default:
-		panic("Invalid test repetition mode: " + params.TestRepetitionMode)
 	}
 
-	if xcodeMajorVersion >= 13 && params.RetryTestsOnFailure {
+	if params.RetryTestsOnFailure {
 		xcodebuildArgs = append(xcodebuildArgs, "-retry-tests-on-failure", "-test-iterations", "2")
 	}
 

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -282,7 +282,7 @@ func handleTestRunError(prevRunParams testRunParams, prevRunResult testRunResult
 
 	if prevRunParams.xcodeMajorVersion < 13 && prevRunParams.buildTestParams.RetryTestsOnFailure {
 		log.Warnf("Test run failed")
-		log.Printf("retryOnTestOrTestRunnerError=true - retrying...")
+		log.Printf("retryTestsOnFailure=true - retrying...")
 
 		prevRunParams.buildTestParams.RetryTestsOnFailure = false
 		prevRunParams.retryOnTestRunnerError = false

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -250,10 +250,6 @@ func createXcodebuildTestArgs(params models.XcodebuildTestParams, xcodeMajorVers
 		break
 	}
 
-	if params.RetryTestsOnFailure {
-		xcodebuildArgs = append(xcodebuildArgs, "-retry-tests-on-failure", "-test-iterations", "2")
-	}
-
 	if params.AdditionalOptions != "" {
 		options, err := shellquote.Split(params.AdditionalOptions)
 		if err != nil {

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -119,7 +119,7 @@ func runPrettyXcodebuildCmd(useStdOut bool, xcprettyArgs []string, xcodebuildArg
 	return buildOutBuffer.String(), 0, nil
 }
 
-func runBuild(buildParams models.XcodeBuildParamsModel, outputTool string) (string, int, error) {
+func runBuild(buildParams models.XcodebuildParams, outputTool string) (string, int, error) {
 	xcodebuildArgs := []string{buildParams.Action, buildParams.ProjectPath, "-scheme", buildParams.Scheme}
 	if buildParams.CleanBuild {
 		xcodebuildArgs = append(xcodebuildArgs, "clean")
@@ -142,7 +142,7 @@ func runBuild(buildParams models.XcodeBuildParamsModel, outputTool string) (stri
 }
 
 type testRunParams struct {
-	buildTestParams                    models.XcodeBuildTestParamsModel
+	buildTestParams                    models.XcodebuildTestParams
 	outputTool                         string
 	xcprettyOptions                    string
 	retryOnTestRunnerError             bool
@@ -195,7 +195,7 @@ func createXCPrettyArgs(options string) ([]string, error) {
 	return args, nil
 }
 
-func createXcodebuildTestArgs(params models.XcodeBuildTestParamsModel, xcodeMajorVersion int) ([]string, error) {
+func createXcodebuildTestArgs(params models.XcodebuildTestParams, xcodeMajorVersion int) ([]string, error) {
 	buildParams := params.BuildParams
 
 	xcodebuildArgs := []string{buildParams.Action, buildParams.ProjectPath, "-scheme", buildParams.Scheme}

--- a/xcpretty.go
+++ b/xcpretty.go
@@ -64,5 +64,5 @@ func handleXcprettyInstallError(err error) (string, error) {
 
 	log.Warnf("%s", err)
 	log.Printf("Switching to xcodebuild for output tool")
-	return xcodeBuildTool, nil
+	return xcodebuildTool, nil
 }


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MAJOR_ [version update](https://semver.org/)

### Context
**We are adding Xcode 13's Test Repetition features to the Xcode Test step.**
* This includes choosing test repetition mode, setting maximum test repetitions and rerunning tests in a different process.

**`should_retry_test_on_fail` will be unavailable from Xcode 13.**
* Otherwise it would conflict with new Test Repetition support.

### Changes
* **New step input: `test_repetition_mode`.**
    * Works exactly like `Test Repetition Mode` in Xcode's Test Plan Configuration window.
    * Possible values: `none`, `until_failure`, `retry_on_failure` and `up_until_maximum_repetitions`.
    * Sets the appropriate flag on `xcodebuild`.
    * Will slightly change with the addition of `maximum_test_repetitions`.
* **Removed test repetition-based test retry above Xcode 13 if `should_retry_test_on_fail` is turned on.**
* **Updated existing test retry E2E tests to only run on Xcode 11 and 12 stacks.**
    * These are testing `should_retry_test_on_fail` which will not be available from Xcode 13.
    * These should run on Xcode 10 as well, but implementing that would be too much of an effort for this PR.
* **Added E2E tests to ensure that `test_repetition_mode` and `should_retry_test_on_fail` are only available on appropriate stacks.**
    * Otherwise, the step should fail early.
* Renamed some structs/variables for consistency.

### Decisions
* Using `should_retry_test_on_fail` on Xcode 13 and above should fail with an error rather than be ignored with a warning.

### Out of Scope
* **Testing Test Repetition Mode:** it only makes sense to test this logic together with the addition of `maximum_test_repetitions`, so tests will be added in a follow-up PR.
* **Finalizing description:** description will be finalized in a separate PR before release.