### PR TITLE
STEP-1203: Add Maximum Test Repetitions step input

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -284,7 +284,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallySucceedingTests"
@@ -336,7 +336,7 @@ workflows:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 2
     - EXPECT_TEST_FAILURE: "true"
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallySucceedingTests"
@@ -387,7 +387,7 @@ workflows:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 1
     - EXPECT_TEST_FAILURE: "true"
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallySucceedingTests"
@@ -427,7 +427,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallySucceedingTests"
@@ -477,7 +477,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 2
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallySucceedingTests"
@@ -520,7 +520,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 2
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallySucceedingTests"
@@ -563,7 +563,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 2
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallyFailingTests"
@@ -613,7 +613,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallyFailingTests"
@@ -656,7 +656,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 3
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallyFailingTests"
@@ -699,7 +699,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 2
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallyFailingTests"
@@ -749,7 +749,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallyFailingTests"
@@ -792,7 +792,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 3
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallyFailingTests"

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -632,7 +632,7 @@ workflows:
     - _run
     - _check_outputs
 
-  test_test_repetition_mode_until_failure_3_iterations_succeeds:
+  test_test_repetition_mode_until_failure_3_iterations_fails:
     before_run:
     - _expose_xcode_version
     steps:
@@ -646,15 +646,22 @@ workflows:
               exit 0
             fi
             envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
-    - bitrise-run:
+    - script:
+        title: Start a failing workflow, wrapped in a script.
         run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
         inputs:
-        - workflow_id: utility_test_test_repetition_mode_until_failure_3_iterations_succeeds
-        - bitrise_config_path: ./e2e/bitrise.yml
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_test_repetition_mode_until_failure_3_iterations_fails
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was expected to fail, exit code not 1."
+              exit 1
+            fi
 
-  utility_test_test_repetition_mode_until_failure_3_iterations_succeeds:
+  utility_test_test_repetition_mode_until_failure_3_iterations_fails:
     envs:
-    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 3
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 2
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
     - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
@@ -768,7 +775,7 @@ workflows:
     - _run
     - _check_outputs
 
-  test_test_repetition_mode_up_until_maximum_repetitions_3_iterations_succeeds:
+  test_test_repetition_mode_up_until_maximum_repetitions_3_iterations_fails:
     before_run:
     - _expose_xcode_version
     steps:
@@ -782,15 +789,22 @@ workflows:
               exit 0
             fi
             envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
-    - bitrise-run:
+    - script:
+        title: Start a failing workflow, wrapped in a script.
         run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
         inputs:
-        - workflow_id: utility_test_test_repetition_mode_up_until_maximum_repetitions_3_iterations_succeeds
-        - bitrise_config_path: ./e2e/bitrise.yml
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_test_repetition_mode_up_until_maximum_repetitions_3_iterations_fails
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was expected to fail, exit code not 1."
+              exit 1
+            fi
 
-  utility_test_test_repetition_mode_up_until_maximum_repetitions_3_iterations_succeeds:
+  utility_test_test_repetition_mode_up_until_maximum_repetitions_3_iterations_fails:
     envs:
-    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 3
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 2
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
     - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -403,6 +403,142 @@ workflows:
     - _run
     - _check_outputs
 
+  test_test_repetition_mode_retry_on_failure_2_iterations_succeeds:
+    before_run:
+      - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - workflow_id: utility_test_test_repetition_mode_retry_on_failure_2_iterations_succeeds
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_test_repetition_mode_retry_on_failure_2_iterations_succeeds:
+    envs:
+    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: master
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "FlakyTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "retry_on_failure"
+    - MAXIMUM_TEST_REPETITIONS: 2
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "false"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_flaky_tests_in_test_app
+    - _run
+    - _check_outputs
+
+  test_test_repetition_mode_retry_on_failure_2_iterations_fails:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - script:
+        title: Start a failing workflow, wrapped in a script.
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_test_repetition_mode_retry_on_failure_2_iterations_fails
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was expected to fail, exit code not 1."
+              exit 1
+            fi
+
+  utility_test_test_repetition_mode_retry_on_failure_2_iterations_fails:
+    envs:
+    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 2
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: master
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "FlakyTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "retry_on_failure"
+    - MAXIMUM_TEST_REPETITIONS: 2
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "true"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_flaky_tests_in_test_app
+    - _run
+    - _check_outputs
+
+  test_test_repetition_mode_retry_on_failure_3_iterations_succeeds:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - workflow_id: utility_test_test_repetition_mode_retry_on_failure_3_iterations_succeeds
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_test_repetition_mode_retry_on_failure_3_iterations_succeeds:
+    envs:
+    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 2
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: master
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "FlakyTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "retry_on_failure"
+    - MAXIMUM_TEST_REPETITIONS: 3
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "false"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_flaky_tests_in_test_app
+    - _run
+    - _check_outputs
+
   test_simulator_os_version:
     before_run:
     - _expose_xcode_version
@@ -516,6 +652,7 @@ workflows:
         - scheme: $BITRISE_SCHEME
         - test_plan: $TEST_PLAN
         - test_repetition_mode: $TEST_REPETITION_MODE
+        - maximum_test_repetitions: $MAXIMUM_TEST_REPETITIONS
         - simulator_device: $XCODE_SIMULATOR_DEVICE
         - simulator_os_version: $XCODE_SIMULATOR_OS_VERSION
         - simulator_platform: $XCODE_SIMULATOR_PLATFORM

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -242,18 +242,18 @@ workflows:
 
   utility_test_test_repetition_mode_not_available_below_xcode_13:
     envs:
-      - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-      - TEST_APP_BRANCH: master
-      - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
-      - BITRISE_SCHEME: BullsEye
-      - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
-      - XCODE_SIMULATOR_OS_VERSION: "latest"
-      - XCODE_SIMULATOR_PLATFORM: iOS Simulator
-      - SINGLE_BUILD: "true"
-      - XCODE_OUTPUT_TOOL: xcodebuild
-      - RETRY_ON_FAILURE: "no"
-      - TEST_REPETITION_MODE: "retry_on_failure"
-      - CACHE_LEVEL: "swift_packages"
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: master
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - RETRY_ON_FAILURE: "no"
+    - TEST_REPETITION_MODE: "retry_on_failure"
+    - CACHE_LEVEL: "swift_packages"
     after_run:
     - _run
 
@@ -322,14 +322,14 @@ workflows:
         title: Start a failing workflow, wrapped in a script.
         run_if: '{{enveq "XCODE_MAJOR_VERSION_BETWEEN_11_AND_12" "true"}}'
         inputs:
-          - content: |-
-              #!/bin/env bash
-              set -x # Do not set -e as bitrise command is expected to fail
-              bitrise run --config=./e2e/bitrise.yml utility_test_should_retry_test_on_fail_fails
-              if [ $? -ne 1 ] ; then
-                echo "Workflow was expected to fail, exit code not 1."
-                exit 1
-              fi
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_should_retry_test_on_fail_fails
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was expected to fail, exit code not 1."
+              exit 1
+            fi
 
   utility_test_should_retry_test_on_fail_fails:
     envs:
@@ -373,14 +373,14 @@ workflows:
         title: Start a failing workflow, wrapped in a script.
         run_if: '{{enveq "XCODE_MAJOR_VERSION_BETWEEN_11_AND_12" "true"}}'
         inputs:
-          - content: |-
-              #!/bin/env bash
-              set -x # Do not set -e as bitrise command is expected to fail
-              bitrise run --config=./e2e/bitrise.yml utility_test_should_retry_test_on_fail_off
-              if [ $? -ne 1 ] ; then
-                echo "Workflow was expected to fail, exit code not 1."
-                exit 1
-              fi
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_should_retry_test_on_fail_off
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was expected to fail, exit code not 1."
+              exit 1
+            fi
 
   utility_test_should_retry_test_on_fail_off:
     envs:
@@ -675,6 +675,142 @@ workflows:
     - _run
     - _check_outputs
 
+  test_test_repetition_mode_up_until_maximum_repetitions_2_iterations_succeeds:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - workflow_id: utility_test_test_repetition_mode_up_until_maximum_repetitions_2_iterations_succeeds
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_test_repetition_mode_up_until_maximum_repetitions_2_iterations_succeeds:
+    envs:
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 2
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "EventuallyFailingTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "up_until_maximum_repetitions"
+    - MAXIMUM_TEST_REPETITIONS: 2
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "false"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_initial_test_successes_in_test_app
+    - _run
+    - _check_outputs
+
+  test_test_repetition_mode_up_until_maximum_repetitions_2_iterations_fails:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - script:
+        title: Start a failing workflow, wrapped in a script.
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_test_repetition_mode_up_until_maximum_repetitions_2_iterations_fails
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was expected to fail, exit code not 1."
+              exit 1
+            fi
+
+  utility_test_test_repetition_mode_up_until_maximum_repetitions_2_iterations_fails:
+    envs:
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 1
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "EventuallyFailingTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "up_until_maximum_repetitions"
+    - MAXIMUM_TEST_REPETITIONS: 2
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "true"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_initial_test_successes_in_test_app
+    - _run
+    - _check_outputs
+
+  test_test_repetition_mode_up_until_maximum_repetitions_3_iterations_succeeds:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - workflow_id: utility_test_test_repetition_mode_up_until_maximum_repetitions_3_iterations_succeeds
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_test_repetition_mode_up_until_maximum_repetitions_3_iterations_succeeds:
+    envs:
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 3
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "EventuallyFailingTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "up_until_maximum_repetitions"
+    - MAXIMUM_TEST_REPETITIONS: 3
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "false"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_initial_test_successes_in_test_app
+    - _run
+    - _check_outputs
+
   test_simulator_os_version:
     before_run:
     - _expose_xcode_version
@@ -718,10 +854,10 @@ workflows:
 
   _set_number_of_initial_test_failures_in_test_app:
     envs:
-      - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: $TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES
-      - XCODE_SIMULATOR_DEVICE: $XCODE_SIMULATOR_DEVICE
-      - XCODE_SIMULATOR_OS_VERSION: $XCODE_SIMULATOR_OS_VERSION
-      - XCODE_SIMULATOR_PLATFORM: $XCODE_SIMULATOR_PLATFORM
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: $TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES
+    - XCODE_SIMULATOR_DEVICE: $XCODE_SIMULATOR_DEVICE
+    - XCODE_SIMULATOR_OS_VERSION: $XCODE_SIMULATOR_OS_VERSION
+    - XCODE_SIMULATOR_PLATFORM: $XCODE_SIMULATOR_PLATFORM
     steps:
     - git::https://github.com/bitrise-steplib/steps-lookup-xcode-simulator:
         inputs:
@@ -750,10 +886,10 @@ workflows:
 
   _set_number_of_initial_test_successes_in_test_app:
     envs:
-      - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: $TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES
-      - XCODE_SIMULATOR_DEVICE: $XCODE_SIMULATOR_DEVICE
-      - XCODE_SIMULATOR_OS_VERSION: $XCODE_SIMULATOR_OS_VERSION
-      - XCODE_SIMULATOR_PLATFORM: $XCODE_SIMULATOR_PLATFORM
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: $TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES
+    - XCODE_SIMULATOR_DEVICE: $XCODE_SIMULATOR_DEVICE
+    - XCODE_SIMULATOR_OS_VERSION: $XCODE_SIMULATOR_OS_VERSION
+    - XCODE_SIMULATOR_PLATFORM: $XCODE_SIMULATOR_PLATFORM
     steps:
     - git::https://github.com/bitrise-steplib/steps-lookup-xcode-simulator:
         inputs:
@@ -792,10 +928,10 @@ workflows:
             rm -rf ./_tmp
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
-          - repository_url: $TEST_APP_URL
-          - clone_into_dir: ./_tmp
-          - branch: $TEST_APP_BRANCH
-    - certificate-and-profile-installer: {}
+        - repository_url: $TEST_APP_URL
+        - clone_into_dir: ./_tmp
+        - branch: $TEST_APP_BRANCH
+    - certificate-and-profile-installer: { }
     - script:
         title: Set 'collect_simulator_diagnostics' input
         inputs:
@@ -817,10 +953,10 @@ workflows:
     - script:
         title: Set MAXIMUM_TEST_REPETITIONS to 3 if not set
         inputs:
-          - content: |-
-              #!/bin/env bash
-              set -eo pipefail
-              envman add --key MAXIMUM_TEST_REPETITIONS --value ${MAXIMUM_TEST_REPETITIONS-3}
+        - content: |-
+            #!/bin/env bash
+            set -eo pipefail
+            envman add --key MAXIMUM_TEST_REPETITIONS --value ${MAXIMUM_TEST_REPETITIONS-3}
     - path::./:
         inputs:
         - project_path: ./_tmp/$BITRISE_PROJECT_PATH

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -405,7 +405,7 @@ workflows:
 
   test_test_repetition_mode_retry_on_failure_2_iterations_succeeds:
     before_run:
-      - _expose_xcode_version
+    - _expose_xcode_version
     steps:
     - script:
         inputs:
@@ -539,6 +539,142 @@ workflows:
     - _run
     - _check_outputs
 
+  test_test_repetition_mode_until_failure_2_iterations_succeeds:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - workflow_id: utility_test_test_repetition_mode_until_failure_2_iterations_succeeds
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_test_repetition_mode_until_failure_2_iterations_succeeds:
+    envs:
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 2
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "EventuallyFailingTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "until_failure"
+    - MAXIMUM_TEST_REPETITIONS: 2
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "false"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_initial_test_successes_in_test_app
+    - _run
+    - _check_outputs
+
+  test_test_repetition_mode_until_failure_2_iterations_fails:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - script:
+        title: Start a failing workflow, wrapped in a script.
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_test_repetition_mode_until_failure_2_iterations_fails
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was expected to fail, exit code not 1."
+              exit 1
+            fi
+
+  utility_test_test_repetition_mode_until_failure_2_iterations_fails:
+    envs:
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 1
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "EventuallyFailingTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "until_failure"
+    - MAXIMUM_TEST_REPETITIONS: 2
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "true"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_initial_test_successes_in_test_app
+    - _run
+    - _check_outputs
+
+  test_test_repetition_mode_until_failure_3_iterations_succeeds:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - workflow_id: utility_test_test_repetition_mode_until_failure_3_iterations_succeeds
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_test_repetition_mode_until_failure_3_iterations_succeeds:
+    envs:
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 3
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "EventuallyFailingTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "until_failure"
+    - MAXIMUM_TEST_REPETITIONS: 3
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "false"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_initial_test_successes_in_test_app
+    - _run
+    - _check_outputs
+
   test_simulator_os_version:
     before_run:
     - _expose_xcode_version
@@ -593,7 +729,7 @@ workflows:
         - simulator_os_version: $XCODE_SIMULATOR_OS_VERSION
         - simulator_platform: $XCODE_SIMULATOR_PLATFORM
     - script:
-        title: Set number of flaky test failures on the Simulator for the app io.bitrise.BullsEye
+        title: Set number of flaky test number of initial failures on the Simulator for the app io.bitrise.BullsEye
         inputs:
         - content: |-
             set -ex
@@ -611,6 +747,38 @@ workflows:
             xcrun simctl boot $XCODE_SIMULATOR_UDID
             set -e
             xcrun simctl spawn $XCODE_SIMULATOR_UDID defaults write io.bitrise.BullsEye eventually_succeeding_test_number_of_failures $TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES
+
+  _set_number_of_initial_test_successes_in_test_app:
+    envs:
+      - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: $TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES
+      - XCODE_SIMULATOR_DEVICE: $XCODE_SIMULATOR_DEVICE
+      - XCODE_SIMULATOR_OS_VERSION: $XCODE_SIMULATOR_OS_VERSION
+      - XCODE_SIMULATOR_PLATFORM: $XCODE_SIMULATOR_PLATFORM
+    steps:
+    - git::https://github.com/bitrise-steplib/steps-lookup-xcode-simulator:
+        inputs:
+        - simulator_device: $XCODE_SIMULATOR_DEVICE
+        - simulator_os_version: $XCODE_SIMULATOR_OS_VERSION
+        - simulator_platform: $XCODE_SIMULATOR_PLATFORM
+    - script:
+        title: Set number of flaky test number of initial successes on the Simulator for the app io.bitrise.BullsEye
+        inputs:
+        - content: |-
+            set -ex
+            if [[ -x $TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES ]]; then
+              echo "Variable TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES is unset"
+              exit 1
+            fi
+            set +e
+            xcrun simctl shutdown $XCODE_SIMULATOR_UDID
+            # Reset UserDefaults to clean state
+            set -e
+            xcrun simctl erase $XCODE_SIMULATOR_UDID
+            # simctl boot fails if Simulator already booted, ignore
+            set +e
+            xcrun simctl boot $XCODE_SIMULATOR_UDID
+            set -e
+            xcrun simctl spawn $XCODE_SIMULATOR_UDID defaults write io.bitrise.BullsEye eventually_failing_test_number_of_successes $TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES
 
   _run:
     before_run:
@@ -646,6 +814,13 @@ workflows:
             #!/bin/env bash
             set -eo pipefail
             envman add --key TEST_REPETITION_MODE --value ${TEST_REPETITION_MODE-none}
+    - script:
+        title: Set MAXIMUM_TEST_REPETITIONS to 3 if not set
+        inputs:
+          - content: |-
+              #!/bin/env bash
+              set -eo pipefail
+              envman add --key MAXIMUM_TEST_REPETITIONS --value ${MAXIMUM_TEST_REPETITIONS-3}
     - path::./:
         inputs:
         - project_path: ./_tmp/$BITRISE_PROJECT_PATH

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -170,7 +170,7 @@ workflows:
     - _check_outputs
     - _check_cache
 
-  test_retry_on_failure_not_available_above_xcode_13:
+  test_should_retry_test_on_fail_not_available_above_xcode_13:
     before_run:
     - _expose_xcode_version
     steps:
@@ -191,13 +191,13 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -x # Do not set -e as bitrise command is expected to fail
-            bitrise run --config=./e2e/bitrise.yml utility_test_retry_on_failure_not_available_above_xcode_13
+            bitrise run --config=./e2e/bitrise.yml utility_test_should_retry_test_on_fail_not_available_above_xcode_13
             if [ $? -ne 1 ] ; then
               echo "Workflow was expected to fail, exit code not 1."
               exit 1
             fi
 
-  utility_test_retry_on_failure_not_available_above_xcode_13:
+  utility_test_should_retry_test_on_fail_not_available_above_xcode_13:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
     - TEST_APP_BRANCH: master
@@ -213,7 +213,7 @@ workflows:
     after_run:
     - _run
 
-  test_repetition_mode_not_available_below_xcode_13:
+  test_test_repetition_mode_not_available_below_xcode_13:
     before_run:
     - _expose_xcode_version
     steps:
@@ -234,13 +234,13 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -x # Do not set -e as bitrise command is expected to fail
-            bitrise run --config=./e2e/bitrise.yml utility_test_repetition_mode_not_available_below_xcode_13
+            bitrise run --config=./e2e/bitrise.yml utility_test_test_repetition_mode_not_available_below_xcode_13
             if [ $? -ne 1 ] ; then
               echo "Workflow was expected to fail, exit code not 1."
               exit 1
             fi
 
-  utility_test_repetition_mode_not_available_below_xcode_13:
+  utility_test_test_repetition_mode_not_available_below_xcode_13:
     envs:
       - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
       - TEST_APP_BRANCH: master
@@ -257,7 +257,7 @@ workflows:
     after_run:
     - _run
 
-  test_retry_succeeds:
+  test_should_retry_test_on_fail_succeeds:
     before_run:
     - _expose_xcode_version
     steps:
@@ -277,10 +277,10 @@ workflows:
     - bitrise-run:
         run_if: '{{enveq "XCODE_MAJOR_VERSION_BETWEEN_11_AND_12" "true"}}'
         inputs:
-        - workflow_id: utility_test_retry_succeeds
+        - workflow_id: utility_test_should_retry_test_on_fail_succeeds
         - bitrise_config_path: ./e2e/bitrise.yml
 
-  utility_test_retry_succeeds:
+  utility_test_should_retry_test_on_fail_succeeds:
     envs:
     - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
@@ -301,7 +301,7 @@ workflows:
     - _run
     - _check_outputs
 
-  test_retry_fails:
+  test_should_retry_test_on_fail_fails:
     before_run:
     - _expose_xcode_version
     steps:
@@ -325,13 +325,13 @@ workflows:
           - content: |-
               #!/bin/env bash
               set -x # Do not set -e as bitrise command is expected to fail
-              bitrise run --config=./e2e/bitrise.yml utility_test_retry_fails
+              bitrise run --config=./e2e/bitrise.yml utility_test_should_retry_test_on_fail_fails
               if [ $? -ne 1 ] ; then
                 echo "Workflow was expected to fail, exit code not 1."
                 exit 1
               fi
 
-  utility_test_retry_fails:
+  utility_test_should_retry_test_on_fail_fails:
     envs:
     - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 2
     - EXPECT_TEST_FAILURE: "true"
@@ -352,7 +352,7 @@ workflows:
     - _run
     - _check_outputs
 
-  test_no_retry_on_failure:
+  test_should_retry_test_on_fail_off:
     before_run:
     - _expose_xcode_version
     steps:
@@ -376,13 +376,13 @@ workflows:
           - content: |-
               #!/bin/env bash
               set -x # Do not set -e as bitrise command is expected to fail
-              bitrise run --config=./e2e/bitrise.yml utility_test_no_retry_on_failure
+              bitrise run --config=./e2e/bitrise.yml utility_test_should_retry_test_on_fail_off
               if [ $? -ne 1 ] ; then
                 echo "Workflow was expected to fail, exit code not 1."
                 exit 1
               fi
 
-  utility_test_no_retry_on_failure:
+  utility_test_should_retry_test_on_fail_off:
     envs:
     - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
     - EXPECT_TEST_FAILURE: "true"

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -282,12 +282,12 @@ workflows:
 
   utility_test_should_retry_test_on_fail_succeeds:
     envs:
-    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
-    - TEST_PLAN: "FlakyTests"
+    - TEST_PLAN: "EventuallySucceedingTests"
     - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
     - XCODE_SIMULATOR_OS_VERSION: "latest"
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
@@ -297,7 +297,7 @@ workflows:
     - EXPECT_TEST_FAILURE: "false"
     - CACHE_LEVEL: "swift_packages"
     after_run:
-    - _set_number_of_flaky_tests_in_test_app
+    - _set_number_of_initial_test_failures_in_test_app
     - _run
     - _check_outputs
 
@@ -333,13 +333,13 @@ workflows:
 
   utility_test_should_retry_test_on_fail_fails:
     envs:
-    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 2
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 2
     - EXPECT_TEST_FAILURE: "true"
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
-    - TEST_PLAN: "FlakyTests"
+    - TEST_PLAN: "EventuallySucceedingTests"
     - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
     - XCODE_SIMULATOR_OS_VERSION: "latest"
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
@@ -348,7 +348,7 @@ workflows:
     - RETRY_ON_FAILURE: "yes"
     - CACHE_LEVEL: "swift_packages"
     after_run:
-    - _set_number_of_flaky_tests_in_test_app
+    - _set_number_of_initial_test_failures_in_test_app
     - _run
     - _check_outputs
 
@@ -384,13 +384,13 @@ workflows:
 
   utility_test_should_retry_test_on_fail_off:
     envs:
-    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 1
     - EXPECT_TEST_FAILURE: "true"
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
-    - TEST_PLAN: "FlakyTests"
+    - TEST_PLAN: "EventuallySucceedingTests"
     - XCODE_SIMULATOR_DEVICE: iPhone 12
     - XCODE_SIMULATOR_OS_VERSION: "latest"
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
@@ -399,7 +399,7 @@ workflows:
     - RETRY_ON_FAILURE: "no"
     - CACHE_LEVEL: "swift_packages"
     after_run:
-    - _set_number_of_flaky_tests_in_test_app
+    - _set_number_of_initial_test_failures_in_test_app
     - _run
     - _check_outputs
 
@@ -425,12 +425,12 @@ workflows:
 
   utility_test_test_repetition_mode_retry_on_failure_2_iterations_succeeds:
     envs:
-    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 1
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
-    - TEST_PLAN: "FlakyTests"
+    - TEST_PLAN: "EventuallySucceedingTests"
     - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
     - XCODE_SIMULATOR_OS_VERSION: "latest"
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
@@ -442,7 +442,7 @@ workflows:
     - EXPECT_TEST_FAILURE: "false"
     - CACHE_LEVEL: "swift_packages"
     after_run:
-    - _set_number_of_flaky_tests_in_test_app
+    - _set_number_of_initial_test_failures_in_test_app
     - _run
     - _check_outputs
 
@@ -475,12 +475,12 @@ workflows:
 
   utility_test_test_repetition_mode_retry_on_failure_2_iterations_fails:
     envs:
-    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 2
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 2
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
-    - TEST_PLAN: "FlakyTests"
+    - TEST_PLAN: "EventuallySucceedingTests"
     - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
     - XCODE_SIMULATOR_OS_VERSION: "latest"
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
@@ -492,7 +492,7 @@ workflows:
     - EXPECT_TEST_FAILURE: "true"
     - CACHE_LEVEL: "swift_packages"
     after_run:
-    - _set_number_of_flaky_tests_in_test_app
+    - _set_number_of_initial_test_failures_in_test_app
     - _run
     - _check_outputs
 
@@ -518,12 +518,12 @@ workflows:
 
   utility_test_test_repetition_mode_retry_on_failure_3_iterations_succeeds:
     envs:
-    - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: 2
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: 2
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: master
+    - TEST_APP_BRANCH: STEP-1203-split-flaky-test-cases
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
-    - TEST_PLAN: "FlakyTests"
+    - TEST_PLAN: "EventuallySucceedingTests"
     - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
     - XCODE_SIMULATOR_OS_VERSION: "latest"
     - XCODE_SIMULATOR_PLATFORM: iOS Simulator
@@ -535,7 +535,7 @@ workflows:
     - EXPECT_TEST_FAILURE: "false"
     - CACHE_LEVEL: "swift_packages"
     after_run:
-    - _set_number_of_flaky_tests_in_test_app
+    - _set_number_of_initial_test_failures_in_test_app
     - _run
     - _check_outputs
 
@@ -580,9 +580,9 @@ workflows:
     - _run
     - _check_outputs
 
-  _set_number_of_flaky_tests_in_test_app:
+  _set_number_of_initial_test_failures_in_test_app:
     envs:
-      - TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES: $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
+      - TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES: $TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES
       - XCODE_SIMULATOR_DEVICE: $XCODE_SIMULATOR_DEVICE
       - XCODE_SIMULATOR_OS_VERSION: $XCODE_SIMULATOR_OS_VERSION
       - XCODE_SIMULATOR_PLATFORM: $XCODE_SIMULATOR_PLATFORM
@@ -597,8 +597,8 @@ workflows:
         inputs:
         - content: |-
             set -ex
-            if [[ -x $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES ]]; then
-              echo "Variable TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES is unset"
+            if [[ -x $TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES ]]; then
+              echo "Variable TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES is unset"
               exit 1
             fi
             set +e
@@ -610,7 +610,7 @@ workflows:
             set +e
             xcrun simctl boot $XCODE_SIMULATOR_UDID
             set -e
-            xcrun simctl spawn $XCODE_SIMULATOR_UDID defaults write io.bitrise.BullsEye flaky_test_number_of_failures $TEST_APP_FLAKY_TEST_NUMBER_OF_FAILURES
+            xcrun simctl spawn $XCODE_SIMULATOR_UDID defaults write io.bitrise.BullsEye eventually_succeeding_test_number_of_failures $TEST_APP_NUMBER_OF_INITIAL_TEST_FAILURES
 
   _run:
     before_run:

--- a/main.go
+++ b/main.go
@@ -263,6 +263,10 @@ func (s Step) ProcessConfig() (Config, error) {
 		return Config{}, errors.New("Test Repetition Mode (test_repetition_mode) is not available below Xcode 13")
 	}
 
+	if input.TestRepetitionMode != none && input.MaximumTestRepetitions < 1 {
+		return Config{}, fmt.Errorf("invalid number of Maximum Test Repetitions (maximum_test_repetitions): %d, should be greater than 0", input.MaximumTestRepetitions)
+	}
+
 	if input.RetryTestsOnFailure && xcodeMajorVersion > 12 {
 		return Config{}, errors.New("Should retry test on failure? (should_retry_test_on_fail) is not available above Xcode 12; use test_repetition_mode=retry_on_failure instead")
 	}

--- a/main.go
+++ b/main.go
@@ -280,7 +280,8 @@ func (s Step) ProcessConfig() (Config, error) {
 		SimulatorID:       sim.ID,
 		IsSimulatorBooted: sim.Status != simulatorShutdownState,
 
-		TestRepetitionMode: input.TestRepetitionMode,
+		TestRepetitionMode:     input.TestRepetitionMode,
+		MaximumTestRepetitions: input.MaximumTestRepetitions,
 
 		OutputTool:         input.OutputTool,
 		IsCleanBuild:       input.IsCleanBuild,

--- a/main.go
+++ b/main.go
@@ -404,14 +404,15 @@ func (s Step) Run(cfg Config) (Result, error) {
 	xcresultPath := path.Join(tempDir, "Test.xcresult")
 
 	testParams := models.XcodebuildTestParams{
-		BuildParams:          buildParams,
-		TestPlan:             cfg.TestPlan,
-		TestOutputDir:        xcresultPath,
-		TestRepetitionMode:   cfg.TestRepetitionMode,
-		BuildBeforeTest:      cfg.BuildBeforeTesting,
-		GenerateCodeCoverage: cfg.GenerateCodeCoverageFiles,
-		RetryTestsOnFailure:  cfg.RetryTestsOnFailure,
-		AdditionalOptions:    cfg.XcodebuildTestOptions,
+		BuildParams:            buildParams,
+		TestPlan:               cfg.TestPlan,
+		TestOutputDir:          xcresultPath,
+		TestRepetitionMode:     cfg.TestRepetitionMode,
+		MaximumTestRepetitions: cfg.MaximumTestRepetitions,
+		BuildBeforeTest:        cfg.BuildBeforeTesting,
+		GenerateCodeCoverage:   cfg.GenerateCodeCoverageFiles,
+		RetryTestsOnFailure:    cfg.RetryTestsOnFailure,
+		AdditionalOptions:      cfg.XcodebuildTestOptions,
 	}
 
 	if cfg.IsSingleBuild {

--- a/main.go
+++ b/main.go
@@ -263,8 +263,8 @@ func (s Step) ProcessConfig() (Config, error) {
 		return Config{}, errors.New("Test Repetition Mode (test_repetition_mode) is not available below Xcode 13")
 	}
 
-	if input.TestRepetitionMode != none && input.MaximumTestRepetitions < 1 {
-		return Config{}, fmt.Errorf("invalid number of Maximum Test Repetitions (maximum_test_repetitions): %d, should be greater than 0", input.MaximumTestRepetitions)
+	if input.TestRepetitionMode != none && input.MaximumTestRepetitions < 2 {
+		return Config{}, fmt.Errorf("invalid number of Maximum Test Repetitions (maximum_test_repetitions): %d, should be more than 1", input.MaximumTestRepetitions)
 	}
 
 	if input.RetryTestsOnFailure && xcodeMajorVersion > 12 {

--- a/main.go
+++ b/main.go
@@ -90,7 +90,8 @@ type Input struct {
 	SimulatorOsVersion string `env:"simulator_os_version,required"`
 
 	// Test Repetition
-	TestRepetitionMode string `env:"test_repetition_mode,opt[none,until_failure,retry_on_failure,up_until_maximum_repetitions]"`
+	TestRepetitionMode     string `env:"test_repetition_mode,opt[none,until_failure,retry_on_failure,up_until_maximum_repetitions]"`
+	MaximumTestRepetitions int    `env:"maximum_test_repetitions,required"`
 
 	// Test Run Configs
 	OutputTool            string `env:"output_tool,opt[xcpretty,xcodebuild]"`
@@ -127,7 +128,8 @@ type Config struct {
 	SimulatorID       string
 	IsSimulatorBooted bool
 
-	TestRepetitionMode string
+	TestRepetitionMode     string
+	MaximumTestRepetitions int
 
 	OutputTool         string
 	IsCleanBuild       bool

--- a/models/models.go
+++ b/models/models.go
@@ -12,13 +12,14 @@ type XcodebuildParams struct {
 
 // XcodebuildTestParams ...
 type XcodebuildTestParams struct {
-	BuildParams          XcodebuildParams
-	TestPlan             string
-	TestOutputDir        string
-	TestRepetitionMode   string
-	CleanBuild           bool
-	BuildBeforeTest      bool
-	GenerateCodeCoverage bool
-	RetryTestsOnFailure  bool
-	AdditionalOptions    string
+	BuildParams            XcodebuildParams
+	TestPlan               string
+	TestOutputDir          string
+	TestRepetitionMode     string
+	MaximumTestRepetitions int
+	CleanBuild             bool
+	BuildBeforeTest        bool
+	GenerateCodeCoverage   bool
+	RetryTestsOnFailure    bool
+	AdditionalOptions      string
 }

--- a/step.yml
+++ b/step.yml
@@ -183,8 +183,11 @@ inputs:
     opts:
       title: Maximum Test Repetitions
       category: Test Repetition
+      summary: The maximum number of times a test will repeat based on Test Repetition Mode.
       description: |-
         The maximum number of times a test will repeat based on Test Repetition Mode.
+        
+        Should be more than 1 if Test Repetition Mode (`test_repetition_mode`) is other than `none`.
       is_required: true
   - verbose: "no"
     opts:

--- a/step.yml
+++ b/step.yml
@@ -179,6 +179,13 @@ inputs:
         - "until_failure"
         - "retry_on_failure"
         - "up_until_maximum_repetitions"
+  - maximum_test_repetitions: 3
+    opts:
+      title: Maximum Test Repetitions
+      category: Test Repetition
+      description: |-
+        The maximum number of times a test will repeat based on Test Repetition Mode.
+      is_required: true
   - verbose: "no"
     opts:
       category: Debug

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -246,8 +247,10 @@ func createXcodebuildTestArgs(params models.XcodebuildTestParams, xcodeMajorVers
 		xcodebuildArgs = append(xcodebuildArgs, "-run-tests-until-failure")
 	case retryOnFailure:
 		xcodebuildArgs = append(xcodebuildArgs, "-retry-tests-on-failure")
-	case upUntilMaximumRepetitions, none:
-		break
+	}
+
+	if params.TestRepetitionMode != none {
+		xcodebuildArgs = append(xcodebuildArgs, "-test-iterations", strconv.Itoa(params.MaximumTestRepetitions))
 	}
 
 	if params.AdditionalOptions != "" {

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -21,10 +21,9 @@ import (
 )
 
 const (
-	none                      = "none"
-	untilFailure              = "until_failure"
-	retryOnFailure            = "retry_on_failure"
-	upUntilMaximumRepetitions = "up_until_maximum_repetitions"
+	none           = "none"
+	untilFailure   = "until_failure"
+	retryOnFailure = "retry_on_failure"
 )
 
 func runXcodebuildCmd(args ...string) (string, int, error) {


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context
**We are adding Xcode 13's Test Repetition features to the Xcode Test step.**
* This includes choosing test repetition mode, setting maximum test repetitions and rerunning tests in a different process.

### Changes
* **New step input: Maximum Test Repetitions (`maximum_test_repetitions`).**
    * Works exactly like `Maximum Test Repetitions` in Xcode's Test Plan Configuration window.
    * Possible values: `2..<` (default: `3`).
    * Sets the appropriate flag on `xcodebuild`: `-test-iterations`.
* **Added E2E tests that test the 3 Test Repetition Modes and Maximum Test Repetitions together** (more details below).
* Separated flaky tests in sample app to eventually succeeding & eventually failing: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test/pull/7.
* Renamed existing E2E tests for `should_retry_test_on_fail` to make it easy to distinguish from new Test Repetition tests.
* Reformatted the entire file to make the indentation of list items consistent.

### Testing
There are 9 new E2E tests designed to test Test Repetition Modes and Maximum Test Repetitions together.

| **Given**                                                                                                                                                                    | **When**         | **Then**            |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|---------------------|
| <ul><li>Sample app test fails 1 time(s), then always succeeds</li> <li>Test Repetition Mode is Retry on Failure</li> <li>Maximum Test Repetitions is 2</li></ul>             | Step is executed | Step should succeed |
| <ul><li>Sample app test fails 2 time(s), then always succeeds</li> <li>Test Repetition Mode is Retry on Failure</li> <li>Maximum Test Repetitions is 2</li></ul>             | Step is executed | Step should fail    |
| <ul><li>Sample app test fails 2 time(s), then always succeeds</li> <li>Test Repetition Mode is Retry on Failure</li> <li>Maximum Test Repetitions is 3</li></ul>             | Step is executed | Step should succeed |
| <ul><li>Sample app test succeeds 2 time(s), then always fails</li> <li>Test Repetition Mode is Until Failure</li> <li>Maximum Test Repetitions is 2</li></ul>                | Step is executed | Step should succeed |
| <ul><li>Sample app test succeeds 1 time(s), then always fails</li> <li>Test Repetition Mode is Until Failure</li> <li>Maximum Test Repetitions is 2</li></ul>                | Step is executed | Step should fail    |
| <ul><li>Sample app test succeeds 2 time(s), then always fails</li> <li>Test Repetition Mode is Until Failure</li> <li>Maximum Test Repetitions is 3</li></ul>                | Step is executed | Step should fail    |
| <ul><li>Sample app test succeeds 2 time(s), then always fails</li> <li>Test Repetition Mode is Up Until Maximum Repetitions</li> <li>Maximum Test Repetitions is 2</li></ul> | Step is executed | Step should succeed |
| <ul><li>Sample app test succeeds 1 time(s), then always fails</li> <li>Test Repetition Mode is Up Until Maximum Repetitions</li> <li>Maximum Test Repetitions is 2</li></ul> | Step is executed | Step should fail    |
| <ul><li>Sample app test succeeds 2 time(s), then always fails</li> <li>Test Repetition Mode is Up Until Maximum Repetitions</li> <li>Maximum Test Repetitions is 3</li></ul> | Step is executed | Step should fail    |

To make testing easier, the sample app now contains 2 kinds of simulated "flaky" tests:
* One that succeeds a predefined number of times, then always fails. This can be used to test if `retry_on_failure` works as intended.
* One the fails a predefined number of times, then always succeeds. This can be used to test if `until_failure` and `up_until_maximum_repetitions` works as intended.

### Out of Scope
* **Finalizing description:** description will be finalized in a separate PR before release.
