### PR TITLE
STEP-1205: Add Relaunch Tests for Each Repetition step input

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -870,6 +870,50 @@ workflows:
     - _run
     - _check_outputs
 
+  test_relaunch_tests_for_each_repetition_succeeds:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - workflow_id: utility_test_relaunch_tests_for_each_repetition_succeeds
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_relaunch_tests_for_each_repetition_succeeds:
+    envs:
+    - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 1
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: STEP-1205-eventually-failing-in-memory-tests
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - TEST_PLAN: "EventuallyFailingInMemoryTests"
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - TEST_REPETITION_MODE: "up_until_maximum_repetitions"
+    - MAXIMUM_TEST_REPETITIONS: 2
+    - RELAUNCH_TESTS_FOR_EACH_REPETITION: "yes"
+    - RETRY_ON_FAILURE: "no"
+    - EXPECT_TEST_FAILURE: "false"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _set_number_of_initial_test_successes_in_test_app
+    - _run
+    - _check_outputs
+
   test_simulator_os_version:
     before_run:
     - _expose_xcode_version

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -894,7 +894,7 @@ workflows:
     envs:
     - TEST_APP_NUMBER_OF_INITIAL_TEST_SUCCESSES: 1
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
-    - TEST_APP_BRANCH: STEP-1205-eventually-failing-in-memory-tests
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
     - BITRISE_SCHEME: BullsEye
     - TEST_PLAN: "EventuallyFailingInMemoryTests"

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -257,6 +257,51 @@ workflows:
     after_run:
     - _run
 
+  test_relaunch_tests_for_each_repetition_not_available_if_test_repetition_mode_is_none:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -e
+            if [[ ${XCODE_MAJOR_VERSION} -lt 13 ]]; then
+              echo "This test case requires Xcode >= 13, skipping..."
+              exit 0
+            fi
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_13 --value "true"
+    - script:
+        title: Start a failing workflow, wrapped in a script.
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_13" "true"}}'
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run --config=./e2e/bitrise.yml utility_test_relaunch_tests_for_each_repetition_not_available_if_test_repetition_mode_is_none
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was expected to fail, exit code not 1."
+              exit 1
+            fi
+
+  utility_test_relaunch_tests_for_each_repetition_not_available_if_test_repetition_mode_is_none:
+    envs:
+    - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
+    - TEST_APP_BRANCH: master
+    - BITRISE_PROJECT_PATH: BullsEye.xcworkspace
+    - BITRISE_SCHEME: BullsEye
+    - XCODE_SIMULATOR_DEVICE: iPhone 8 Plus
+    - XCODE_SIMULATOR_OS_VERSION: "latest"
+    - XCODE_SIMULATOR_PLATFORM: iOS Simulator
+    - SINGLE_BUILD: "true"
+    - XCODE_OUTPUT_TOOL: xcodebuild
+    - RETRY_ON_FAILURE: "no"
+    - TEST_REPETITION_MODE: "none"
+    - RELAUNCH_TESTS_FOR_EACH_REPETITION: "yes"
+    - CACHE_LEVEL: "swift_packages"
+    after_run:
+    - _run
+
   test_should_retry_test_on_fail_succeeds:
     before_run:
     - _expose_xcode_version
@@ -965,12 +1010,19 @@ workflows:
             set -eo pipefail
             envman add --key TEST_REPETITION_MODE --value ${TEST_REPETITION_MODE-none}
     - script:
-        title: Set MAXIMUM_TEST_REPETITIONS to 3 if not set
+        title: Set MAXIMUM_TEST_REPETITIONS to '3' if not set
         inputs:
         - content: |-
             #!/bin/env bash
             set -eo pipefail
             envman add --key MAXIMUM_TEST_REPETITIONS --value ${MAXIMUM_TEST_REPETITIONS-3}
+    - script:
+        title: Set RELAUNCH_TESTS_FOR_EACH_REPETITION to 'no' if not set
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -eo pipefail
+            envman add --key RELAUNCH_TESTS_FOR_EACH_REPETITION --value ${RELAUNCH_TESTS_FOR_EACH_REPETITION-no}
     - path::./:
         inputs:
         - project_path: ./_tmp/$BITRISE_PROJECT_PATH
@@ -978,6 +1030,7 @@ workflows:
         - test_plan: $TEST_PLAN
         - test_repetition_mode: $TEST_REPETITION_MODE
         - maximum_test_repetitions: $MAXIMUM_TEST_REPETITIONS
+        - relaunch_tests_for_each_repetition: $RELAUNCH_TESTS_FOR_EACH_REPETITION
         - simulator_device: $XCODE_SIMULATOR_DEVICE
         - simulator_os_version: $XCODE_SIMULATOR_OS_VERSION
         - simulator_platform: $XCODE_SIMULATOR_PLATFORM

--- a/main.go
+++ b/main.go
@@ -269,8 +269,8 @@ func (s Step) ProcessConfig() (Config, error) {
 		return Config{}, fmt.Errorf("invalid number of Maximum Test Repetitions (maximum_test_repetitions): %d, should be more than 1", input.MaximumTestRepetitions)
 	}
 
-	if input.RelaunchTestsForEachRepetition && xcodeMajorVersion < 13 {
-		return Config{}, errors.New("Relaunch Tests for Each Repetition (relaunch_tests_for_each_repetition) is not available below Xcode 13")
+	if input.RelaunchTestsForEachRepetition && input.TestRepetitionMode == none {
+		return Config{}, errors.New("Relaunch Tests for Each Repetition (relaunch_tests_for_each_repetition) cannot be used if Test Repetition Mode (test_repetition_mode) is 'none'")
 	}
 
 	if input.RetryTestsOnFailure && xcodeMajorVersion > 12 {

--- a/main.go
+++ b/main.go
@@ -90,8 +90,9 @@ type Input struct {
 	SimulatorOsVersion string `env:"simulator_os_version,required"`
 
 	// Test Repetition
-	TestRepetitionMode     string `env:"test_repetition_mode,opt[none,until_failure,retry_on_failure,up_until_maximum_repetitions]"`
-	MaximumTestRepetitions int    `env:"maximum_test_repetitions,required"`
+	TestRepetitionMode             string `env:"test_repetition_mode,opt[none,until_failure,retry_on_failure,up_until_maximum_repetitions]"`
+	MaximumTestRepetitions         int    `env:"maximum_test_repetitions,required"`
+	RelaunchTestsForEachRepetition bool   `env:"relaunch_tests_for_each_repetition,opt[yes,no]"`
 
 	// Test Run Configs
 	OutputTool            string `env:"output_tool,opt[xcpretty,xcodebuild]"`
@@ -128,8 +129,9 @@ type Config struct {
 	SimulatorID       string
 	IsSimulatorBooted bool
 
-	TestRepetitionMode     string
-	MaximumTestRepetitions int
+	TestRepetitionMode            string
+	MaximumTestRepetitions        int
+	RelaunchTestForEachRepetition bool
 
 	OutputTool         string
 	IsCleanBuild       bool
@@ -267,6 +269,10 @@ func (s Step) ProcessConfig() (Config, error) {
 		return Config{}, fmt.Errorf("invalid number of Maximum Test Repetitions (maximum_test_repetitions): %d, should be more than 1", input.MaximumTestRepetitions)
 	}
 
+	if input.RelaunchTestsForEachRepetition && xcodeMajorVersion < 13 {
+		return Config{}, errors.New("Relaunch Tests for Each Repetition (relaunch_tests_for_each_repetition) is not available below Xcode 13")
+	}
+
 	if input.RetryTestsOnFailure && xcodeMajorVersion > 12 {
 		return Config{}, errors.New("Should retry test on failure? (should_retry_test_on_fail) is not available above Xcode 12; use test_repetition_mode=retry_on_failure instead")
 	}
@@ -280,8 +286,9 @@ func (s Step) ProcessConfig() (Config, error) {
 		SimulatorID:       sim.ID,
 		IsSimulatorBooted: sim.Status != simulatorShutdownState,
 
-		TestRepetitionMode:     input.TestRepetitionMode,
-		MaximumTestRepetitions: input.MaximumTestRepetitions,
+		TestRepetitionMode:            input.TestRepetitionMode,
+		MaximumTestRepetitions:        input.MaximumTestRepetitions,
+		RelaunchTestForEachRepetition: input.RelaunchTestsForEachRepetition,
 
 		OutputTool:         input.OutputTool,
 		IsCleanBuild:       input.IsCleanBuild,
@@ -405,15 +412,16 @@ func (s Step) Run(cfg Config) (Result, error) {
 	xcresultPath := path.Join(tempDir, "Test.xcresult")
 
 	testParams := models.XcodebuildTestParams{
-		BuildParams:            buildParams,
-		TestPlan:               cfg.TestPlan,
-		TestOutputDir:          xcresultPath,
-		TestRepetitionMode:     cfg.TestRepetitionMode,
-		MaximumTestRepetitions: cfg.MaximumTestRepetitions,
-		BuildBeforeTest:        cfg.BuildBeforeTesting,
-		GenerateCodeCoverage:   cfg.GenerateCodeCoverageFiles,
-		RetryTestsOnFailure:    cfg.RetryTestsOnFailure,
-		AdditionalOptions:      cfg.XcodebuildTestOptions,
+		BuildParams:                    buildParams,
+		TestPlan:                       cfg.TestPlan,
+		TestOutputDir:                  xcresultPath,
+		TestRepetitionMode:             cfg.TestRepetitionMode,
+		MaximumTestRepetitions:         cfg.MaximumTestRepetitions,
+		RelaunchTestsForEachRepetition: cfg.RelaunchTestForEachRepetition,
+		BuildBeforeTest:                cfg.BuildBeforeTesting,
+		GenerateCodeCoverage:           cfg.GenerateCodeCoverageFiles,
+		RetryTestsOnFailure:            cfg.RetryTestsOnFailure,
+		AdditionalOptions:              cfg.XcodebuildTestOptions,
 	}
 
 	if cfg.IsSingleBuild {

--- a/models/models.go
+++ b/models/models.go
@@ -12,14 +12,15 @@ type XcodebuildParams struct {
 
 // XcodebuildTestParams ...
 type XcodebuildTestParams struct {
-	BuildParams            XcodebuildParams
-	TestPlan               string
-	TestOutputDir          string
-	TestRepetitionMode     string
-	MaximumTestRepetitions int
-	CleanBuild             bool
-	BuildBeforeTest        bool
-	GenerateCodeCoverage   bool
-	RetryTestsOnFailure    bool
-	AdditionalOptions      string
+	BuildParams                    XcodebuildParams
+	TestPlan                       string
+	TestOutputDir                  string
+	TestRepetitionMode             string
+	MaximumTestRepetitions         int
+	RelaunchTestsForEachRepetition bool
+	CleanBuild                     bool
+	BuildBeforeTest                bool
+	GenerateCodeCoverage           bool
+	RetryTestsOnFailure            bool
+	AdditionalOptions              string
 }

--- a/step.yml
+++ b/step.yml
@@ -187,7 +187,7 @@ inputs:
       description: |-
         The maximum number of times a test will repeat based on Test Repetition Mode.
         
-        Should be more than 1 if Test Repetition Mode (`test_repetition_mode`) is other than `none`.
+        Should be more than 1 if the Test Repetition Mode (`test_repetition_mode`) is other than `none`.
       is_required: true
   - relaunch_tests_for_each_repetition: "no"
     opts:
@@ -272,10 +272,10 @@ inputs:
       category: Debug
       title: "Run xcodebuild test only"
       description: |-
-        If `single_build` is set to false, the step runs `xcodebuild OPTIONS build OPTIONS` before the test
-        to generate the project derived data. After that comes `xcodebuild OPTIONS build test OPTIONS`. This command's log is presented in the step's log.
+        If `single_build` is set to false, the Step runs `xcodebuild OPTIONS build OPTIONS` before the test
+        to generate the project derived data. This is followed by `xcodebuild OPTIONS build test OPTIONS`. This command's log is presented in the Step's log.
 
-        If `single_build` is set to true, then the step calls only `xcodebuild OPTIONS build test OPTIONS`.
+        If `single_build` is set to true, then the Step calls only `xcodebuild OPTIONS build test OPTIONS`.
       value_options:
       - "true"
       - "false"

--- a/step.yml
+++ b/step.yml
@@ -5,7 +5,7 @@ description: |-
   This Steps runs all those Xcode tests that are included in your project. 
   The Step will work out of the box if your project has test targets and your Workflow has the **Deploy to Bitrise.io** Step which exports the test results and (code coverage files if needed) to the Test Reports page. 
   This Step does not need any code signing files since the Step deploys only the test results to [bitrise.io](https://www.bitrise.io).
-  
+
   ### Configuring the Step
   If you click into the Step, there are some required input fields whose input must be set in accordance with the Xcode configuration of the project.  
   The **Scheme name** input field must be marked as Shared in Xcode. 
@@ -68,7 +68,7 @@ inputs:
       title: "Test Plan"
       summary: Run tests in a specific Test Plan associated with the Scheme.
       description: |-
-        Run tests in a specific Test Plan associated with the Scheme.  
+        Run tests in a specific Test Plan associated with the Scheme.
         Leave this input empty to run the default Test Plan or Test Targets associated with the Scheme.
   - simulator_device: iPhone 8 Plus
     opts:
@@ -148,7 +148,7 @@ inputs:
         Could make the build faster by adding `COMPILER_INDEX_STORE_ENABLE=NO` flag to the `xcodebuild` command which will disable the indexing during the build.
 
         Indexing is needed for
-        
+
         * Autocomplete
         * Ability to quickly jump to definition
         * Get class and method help by alt clicking.
@@ -189,6 +189,17 @@ inputs:
         
         Should be more than 1 if Test Repetition Mode (`test_repetition_mode`) is other than `none`.
       is_required: true
+  - relaunch_tests_for_each_repetition: "no"
+    opts:
+      title: Relaunch Tests for Each Repetition
+      summary: If enabled, tests will launch in a new process for each repetition.
+      description: |-
+        If enabled, tests will launch in a new process for each repetition.
+
+        By default, tests launch in the same process for each repetition.
+      value_options:
+      - "yes"
+      - "no"
   - verbose: "no"
     opts:
       category: Debug
@@ -261,7 +272,7 @@ inputs:
       category: Debug
       title: "Run xcodebuild test only"
       description: |-
-        If `single_build` is set to false, the step runs `xcodebuild OPTIONS build OPTIONS` before the test 
+        If `single_build` is set to false, the step runs `xcodebuild OPTIONS build OPTIONS` before the test
         to generate the project derived data. After that comes `xcodebuild OPTIONS build test OPTIONS`. This command's log is presented in the step's log.
 
         If `single_build` is set to true, then the step calls only `xcodebuild OPTIONS build test OPTIONS`.
@@ -289,8 +300,8 @@ inputs:
       category: Debug
       title: "Should retry test on failure?"
       description: |-
-       If you set this input to `yes`, the Step will rerun your tests. With Xcode 13 and above, only your failed test cases will be rerun. With older Xcode versions, all test cases will be rerun. 
-        Please note that this feature is only available from Xcode 13 and above, earlier versions support rerunning ALL test cases instead of a specific failed one.  
+       If you set this input to `yes`, the Step will rerun your tests. With Xcode 13 and above, only your failed test cases will be rerun. With older Xcode versions, all test cases will be rerun.
+        Please note that this feature is only available from Xcode 13 and above, earlier versions support rerunning ALL test cases instead of a specific failed one.
       value_options:
         - "yes"
         - "no"

--- a/step.yml
+++ b/step.yml
@@ -68,7 +68,7 @@ inputs:
       title: "Test Plan"
       summary: Run tests in a specific Test Plan associated with the Scheme.
       description: |-
-        Run tests in a specific Test Plan associated with the Scheme.
+        Run tests in a specific Test Plan associated with the Scheme.  
         Leave this input empty to run the default Test Plan or Test Targets associated with the Scheme.
   - simulator_device: iPhone 8 Plus
     opts:
@@ -163,7 +163,7 @@ inputs:
       is_required: true
   - test_repetition_mode: "none"
     opts:
-      title: Test Repetition Mode
+      title: Test Repetition Mode (Available from Xcode 13)
       category: Test Repetition
       summary: Determines how the tests will repeat.
       description: |-
@@ -181,7 +181,7 @@ inputs:
         - "up_until_maximum_repetitions"
   - maximum_test_repetitions: 3
     opts:
-      title: Maximum Test Repetitions
+      title: Maximum Test Repetitions (Available from Xcode 13)
       category: Test Repetition
       summary: The maximum number of times a test will repeat based on Test Repetition Mode.
       description: |-
@@ -191,7 +191,7 @@ inputs:
       is_required: true
   - relaunch_tests_for_each_repetition: "no"
     opts:
-      title: Relaunch Tests for Each Repetition
+      title: Relaunch Tests for Each Repetition (Available from Xcode 13)
       summary: If enabled, tests will launch in a new process for each repetition.
       description: |-
         If enabled, tests will launch in a new process for each repetition.

--- a/step.yml
+++ b/step.yml
@@ -163,7 +163,7 @@ inputs:
       is_required: true
   - test_repetition_mode: "none"
     opts:
-      title: Test Repetition Mode (Available from Xcode 13)
+      title: Test Repetition Mode (Available in Xcode 13+)
       category: Test Repetition
       summary: Determines how the tests will repeat.
       description: |-
@@ -181,7 +181,7 @@ inputs:
         - "up_until_maximum_repetitions"
   - maximum_test_repetitions: 3
     opts:
-      title: Maximum Test Repetitions (Available from Xcode 13)
+      title: Maximum Test Repetitions (Available in Xcode 13+)
       category: Test Repetition
       summary: The maximum number of times a test will repeat based on Test Repetition Mode.
       description: |-
@@ -191,7 +191,7 @@ inputs:
       is_required: true
   - relaunch_tests_for_each_repetition: "no"
     opts:
-      title: Relaunch Tests for Each Repetition (Available from Xcode 13)
+      title: Relaunch Tests for Each Repetition (Available in Xcode 13+)
       summary: If enabled, tests will launch in a new process for each repetition.
       description: |-
         If enabled, tests will launch in a new process for each repetition.

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -252,6 +252,10 @@ func createXcodebuildTestArgs(params models.XcodebuildTestParams, xcodeMajorVers
 		xcodebuildArgs = append(xcodebuildArgs, "-test-iterations", strconv.Itoa(params.MaximumTestRepetitions))
 	}
 
+	if params.RelaunchTestsForEachRepetition {
+		xcodebuildArgs = append(xcodebuildArgs, "-test-repetition-relaunch-enabled", "YES")
+	}
+
 	if params.AdditionalOptions != "" {
 		options, err := shellquote.Split(params.AdditionalOptions)
 		if err != nil {


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context
**We are adding Xcode 13's Test Repetition features to the Xcode Test step.**
* This includes choosing test repetition mode, setting maximum test repetitions and rerunning tests in a different process.

### Changes
* **New step input: Relaunch Tests for Each Repetition (`relaunch_tests_for_each_repetition`).**
    * Works exactly like `Relaunch Tests for Each Repetition` in Xcode's Test Plan Configuration window.
    * Possible values: `yes` or `no`.
    * Sets the appropriate flag on `xcodebuild`: `-relaunch-tests-for-each-repetition`.
    * Can only be used if `Test Repetition Mode` is other than `none`.
* Added eventually failing in-memory tests in sample app: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test/pull/8.
* Added E2E tests for input validation and running eventually failing in-memory tests in separate processes.
* Finalized title & description for the 3 new Test Repetition inputs.
