### PR TITLE
STEP-1207: Modified 'Should retry tests on failure?' test input

### DIFF
--- a/main.go
+++ b/main.go
@@ -274,7 +274,7 @@ func (s Step) ProcessConfig() (Config, error) {
 	}
 
 	if input.RetryTestsOnFailure && xcodeMajorVersion > 12 {
-		return Config{}, errors.New("Should retry test on failure? (should_retry_test_on_fail) is not available above Xcode 12; use test_repetition_mode=retry_on_failure instead")
+		return Config{}, errors.New("Should retry tests on failure? (should_retry_test_on_fail) is not available above Xcode 12; use test_repetition_mode=retry_on_failure instead")
 	}
 
 	return Config{

--- a/step.yml
+++ b/step.yml
@@ -301,9 +301,9 @@ inputs:
     opts:
       category: Debug
       title: "Should retry tests on failure? (Not available in Xcode 13+)"
-      summary: If you set this input to `yes`, the Step will rerun your tests in case of failure.
+      summary: If you set this input to `yes`, the Step will rerun your failed tests.
       description: |-
-        If you set this input to `yes`, the Step will rerun your tests once in case of failure. Note that this will rerun ALL of your tests and just the ones that failed.
+        If you set this input to `yes`, the Step will rerun ALL your tests once in the case of failed test/s. Note that ALL your tests will be rerun, not just the ones that failed.
 
         This input is not available if you are using Xcode 13+. In that case, we recommend using the `retry_on_failure` Test Repetition Mode (test_repetition_mode).
       value_options:

--- a/step.yml
+++ b/step.yml
@@ -68,7 +68,7 @@ inputs:
       title: "Test Plan"
       summary: Run tests in a specific Test Plan associated with the Scheme.
       description: |-
-        Run tests in a specific Test Plan associated with the Scheme.  
+        Run tests in a specific Test Plan associated with the Scheme.
         Leave this input empty to run the default Test Plan or Test Targets associated with the Scheme.
   - simulator_device: iPhone 8 Plus
     opts:
@@ -186,7 +186,7 @@ inputs:
       summary: The maximum number of times a test will repeat based on Test Repetition Mode.
       description: |-
         The maximum number of times a test will repeat based on Test Repetition Mode.
-        
+
         Should be more than 1 if the Test Repetition Mode (`test_repetition_mode`) is other than `none`.
       is_required: true
   - relaunch_tests_for_each_repetition: "no"
@@ -298,10 +298,12 @@ inputs:
   - should_retry_test_on_fail: "no"
     opts:
       category: Debug
-      title: "Should retry test on failure?"
+      title: "Should retry tests on failure? (Not available in Xcode 13+)"
+      summary: If you set this input to `yes`, the Step will rerun your tests in case of failure.
       description: |-
-       If you set this input to `yes`, the Step will rerun your tests. With Xcode 13 and above, only your failed test cases will be rerun. With older Xcode versions, all test cases will be rerun.
-        Please note that this feature is only available from Xcode 13 and above, earlier versions support rerunning ALL test cases instead of a specific failed one.
+        If you set this input to `yes`, the Step will rerun your tests once in case of failure. Note that this will rerun ALL of your tests and just the ones that failed.
+
+        This input is not available if you are using Xcode 13+. In that case, we recommend using the `retry_on_failure` Test Repetition Mode (test_repetition_mode).
       value_options:
         - "yes"
         - "no"

--- a/step.yml
+++ b/step.yml
@@ -69,6 +69,7 @@ inputs:
       summary: Run tests in a specific Test Plan associated with the Scheme.
       description: |-
         Run tests in a specific Test Plan associated with the Scheme.
+
         Leave this input empty to run the default Test Plan or Test Targets associated with the Scheme.
   - simulator_device: iPhone 8 Plus
     opts:
@@ -192,6 +193,7 @@ inputs:
   - relaunch_tests_for_each_repetition: "no"
     opts:
       title: Relaunch Tests for Each Repetition (Available in Xcode 13+)
+      category: Test Repetition
       summary: If enabled, tests will launch in a new process for each repetition.
       description: |-
         If enabled, tests will launch in a new process for each repetition.

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -295,7 +295,7 @@ func handleTestRunError(prevRunParams testRunParams, prevRunResult testRunResult
 		}
 	}
 
-	if prevRunParams.xcodeMajorVersion < 13 && prevRunParams.buildTestParams.RetryTestsOnFailure {
+	if prevRunParams.buildTestParams.RetryTestsOnFailure {
 		log.Warnf("Test run failed")
 		log.Printf("retryTestsOnFailure=true - retrying...")
 

--- a/xcodebuild.go
+++ b/xcodebuild.go
@@ -283,21 +283,21 @@ func handleTestRunError(prevRunParams testRunParams, prevRunResult testRunResult
 		if isStringFoundInOutput(errorPattern, prevRunResult.xcodebuildLog) {
 			log.Warnf("Automatic retry reason found in log: %s", errorPattern)
 			if prevRunParams.retryOnTestRunnerError {
-				log.Printf("retryOnTestRunnerError=true - retrying...")
+				log.Printf("Automatic retry is enabled - retrying...")
 
 				prevRunParams.buildTestParams.RetryTestsOnFailure = false
 				prevRunParams.retryOnTestRunnerError = false
 				return cleanOutputDirAndRerunTest(prevRunParams)
 			}
 
-			log.Errorf("retryOnTestRunnerError=false, no more retry, stopping the test!")
+			log.Errorf("Automatic retry is disabled, no more retry, stopping the test!")
 			return prevRunResult.xcodebuildLog, prevRunResult.exitCode, prevRunResult.err
 		}
 	}
 
 	if prevRunParams.buildTestParams.RetryTestsOnFailure {
 		log.Warnf("Test run failed")
-		log.Printf("retryTestsOnFailure=true - retrying...")
+		log.Printf("'Should retry tests on failure?' (should_retry_test_on_fail) is enabled - retrying...")
 
 		prevRunParams.buildTestParams.RetryTestsOnFailure = false
 		prevRunParams.retryOnTestRunnerError = false


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MAJOR_ [version update](https://semver.org/).

### Context
**We are adding Xcode 13's Test Repetition features to the Xcode Test step.**
* This includes choosing test repetition mode, setting maximum test repetitions and rerunning tests in a different process.
* We are removing the previously added Test Repetition behavior from the `should_retry_test_on_fail` input.

### Changes
**Modified the `should_retry_test_on_fail` step input.**
* Changed title to `Should retry tests on failure? (Not available in Xcode 13+)`.
* Changed description according to behavior changes (see below).
* No longer uses 'Retry on Failure' Test Repetition Mode if running on Xcode 13+. This has already been removed in this PR: https://github.com/bitrise-steplib/steps-xcode-test/pull/173.
