### PR TITLE
Add workaround for Big Sur simulator boot failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -344,6 +344,11 @@ func (s Step) InstallDeps(xcpretty bool) error {
 func (s Step) Run(cfg Config) (Result, error) {
 	log.SetEnableDebugLog(cfg.Verbose)
 
+	err := resetLaunchServices()
+	if err != nil {
+		log.Warnf("Failed to apply simulator boot workaround, error: %s", err)
+	}
+
 	// Boot simulator
 	if cfg.SimulatorDebug != never {
 		log.Infof("Enabling Simulator verbose log for better diagnostics")

--- a/simulator.go
+++ b/simulator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -99,4 +100,38 @@ func simulatorCollectDiagnostics() (string, error) {
 	}
 
 	return diagnosticsOutDir, nil
+}
+
+// Reset launch services database to avoid Big Sur's sporadic failure to find the Simulator App
+// The following error is printed when this happens: "kLSNoExecutableErr: The executable is missing"
+// Details:
+// - https://stackoverflow.com/questions/2182040/the-application-cannot-be-opened-because-its-executable-is-missing/16546673#16546673
+// - https://ss64.com/osx/lsregister.html
+func resetLaunchServices() error {
+	cmd := command.New("sw_vers", "-productVersion")
+	macOSVersion, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	if strings.HasPrefix(macOSVersion, "11.") { // It's Big Sur
+		cmd := command.New("xcode-select", "--print-path")
+		xcodeDevDirPath, err := cmd.RunAndReturnTrimmedCombinedOutput()
+		if err != nil {
+			return err
+		}
+
+		simulatorAppPath := filepath.Join(xcodeDevDirPath, "Applications", "Simulator.app")
+
+		cmdString := "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+		cmd = command.New(cmdString, "-f", simulatorAppPath)
+
+		log.Debugf(cmdString)
+		_, err = cmd.RunAndReturnTrimmedCombinedOutput()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/simulator.go
+++ b/simulator.go
@@ -126,7 +126,7 @@ func resetLaunchServices() error {
 		cmdString := "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 		cmd = command.New(cmdString, "-f", simulatorAppPath)
 
-		log.Debugf(cmdString)
+		log.Infof("Applying launch services reset workaround before booting simulator")
 		_, err = cmd.RunAndReturnTrimmedCombinedOutput()
 		if err != nil {
 			return err


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context
The simulator sometimes fails to boot on Big Sur with the following error:

```
kLSNoExecutableErr: The executable is missing
```

A known workaround is to reset the launch services DB before booting the simulator.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

- Execute workaround command before boot
- Detect OS version and only apply workaround on Big Sur

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

- We try to limit the scope by only running on Big Sur
