### PR TITLE
Step 18 42 errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,13 +30,13 @@ func run() int {
 	xcodeTestRunner := createStep(logger)
 	config, err := xcodeTestRunner.ProcessConfig()
 	if err != nil {
-		logger.Errorf(err.Error())
+		logger.Errorf("Process config: %s", err)
 		return 1
 
 	}
 
 	if err := xcodeTestRunner.InstallDeps(config.LogFormatter == xcodebuild.XcprettyTool); err != nil {
-		logger.Warnf("Failed to install deps: %s", err)
+		logger.Warnf("Install dependencies: %s", err)
 		logger.Printf("Switching to xcodebuild for output tool")
 		config.LogFormatter = xcodebuild.XcodebuildTool
 	}
@@ -45,12 +45,12 @@ func run() int {
 	exportErr := xcodeTestRunner.Export(res, runErr != nil)
 
 	if runErr != nil {
-		logger.Errorf(runErr.Error())
+		logger.Errorf("Run: %s", runErr)
 		return 1
 	}
 
 	if exportErr != nil {
-		logger.Errorf(exportErr.Error())
+		logger.Errorf("Export outputs: %s", err)
 		return 1
 	}
 

--- a/output/output.go
+++ b/output/output.go
@@ -81,7 +81,7 @@ func (e exporter) ExportXcodebuildBuildLog(deployDir, xcodebuildBuildLog string)
 
 	deployPth := filepath.Join(deployDir, "xcodebuild_build.log")
 	if err := command.CopyFile(pth, deployPth); err != nil {
-		return fmt.Errorf("failed to copy xcodebuild output log file from (%s) to (%s), error: %s", pth, deployPth, err)
+		return fmt.Errorf("failed to copy xcodebuild output log file from (%s) to (%s): %w", pth, deployPth, err)
 	}
 
 	if err := e.envRepository.Set("BITRISE_XCODEBUILD_BUILD_LOG_PATH", deployPth); err != nil {
@@ -99,7 +99,7 @@ func (e exporter) ExportXcodebuildTestLog(deployDir, xcodebuildTestLog string) e
 
 	deployPth := filepath.Join(deployDir, "xcodebuild_test.log")
 	if err := command.CopyFile(pth, deployPth); err != nil {
-		return fmt.Errorf("failed to copy xcodebuild output log file from (%s) to (%s), error: %s", pth, deployPth, err)
+		return fmt.Errorf("failed to copy xcodebuild output log file from (%s) to (%s): %w", pth, deployPth, err)
 	}
 
 	if err := e.envRepository.Set("BITRISE_XCODEBUILD_TEST_LOG_PATH", deployPth); err != nil {
@@ -112,7 +112,7 @@ func (e exporter) ExportXcodebuildTestLog(deployDir, xcodebuildTestLog string) e
 func (e exporter) ExportSimulatorDiagnostics(deployDir, pth, name string) error {
 	outputPath := filepath.Join(deployDir, name)
 	if err := ziputil.ZipDir(pth, outputPath, true); err != nil {
-		return fmt.Errorf("failed to compress simulator diagnostics result: %v", err)
+		return fmt.Errorf("failed to compress simulator diagnostics result: %w", err)
 	}
 
 	return nil

--- a/output/output.go
+++ b/output/output.go
@@ -43,19 +43,19 @@ func (e exporter) ExportTestRunResult(failed bool) {
 		status = "failed"
 	}
 	if err := e.envRepository.Set("BITRISE_XCODE_TEST_RESULT", status); err != nil {
-		e.logger.Warnf("Failed to export: BITRISE_XCODE_TEST_RESULT, error: %s", err)
+		e.logger.Warnf("Failed to export: BITRISE_XCODE_TEST_RESULT: %s", err)
 	}
 }
 
 func (e exporter) ExportXCResultBundle(deployDir, xcResultPath, scheme string) {
 	// export xcresult bundle
 	if err := e.envRepository.Set("BITRISE_XCRESULT_PATH", xcResultPath); err != nil {
-		e.logger.Warnf("Failed to export: BITRISE_XCRESULT_PATH, error: %s", err)
+		e.logger.Warnf("Failed to export: BITRISE_XCRESULT_PATH: %s", err)
 	}
 
 	xcresultZipPath := filepath.Join(deployDir, filepath.Base(xcResultPath)+".zip")
 	if err := output.ZipAndExportOutput([]string{xcResultPath}, xcresultZipPath, "BITRISE_XCRESULT_ZIP_PATH"); err != nil {
-		e.logger.Warnf("Failed to export: BITRISE_XCRESULT_ZIP_PATH, error: %s", err)
+		e.logger.Warnf("Failed to export: BITRISE_XCRESULT_ZIP_PATH: %s", err)
 	}
 
 	// export xcresult for the testing addon
@@ -68,7 +68,7 @@ func (e exporter) ExportXCResultBundle(deployDir, xcResultPath, scheme string) {
 			TargetAddonPath:       addonResultPath,
 			TargetAddonBundleName: scheme,
 		}); err != nil {
-			e.logger.Warnf("Failed to export test results, error: %s", err)
+			e.logger.Warnf("Failed to export test results: %s", err)
 		}
 	}
 }
@@ -85,7 +85,7 @@ func (e exporter) ExportXcodebuildBuildLog(deployDir, xcodebuildBuildLog string)
 	}
 
 	if err := e.envRepository.Set("BITRISE_XCODEBUILD_BUILD_LOG_PATH", deployPth); err != nil {
-		e.logger.Warnf("Failed to export: BITRISE_XCODEBUILD_BUILD_LOG_PATH, error: %s", err)
+		e.logger.Warnf("Failed to export: BITRISE_XCODEBUILD_BUILD_LOG_PATH: %s", err)
 	}
 
 	return nil
@@ -94,7 +94,7 @@ func (e exporter) ExportXcodebuildBuildLog(deployDir, xcodebuildBuildLog string)
 func (e exporter) ExportXcodebuildTestLog(deployDir, xcodebuildTestLog string) error {
 	pth, err := saveRawOutputToLogFile(xcodebuildTestLog)
 	if err != nil {
-		e.logger.Warnf("Failed to save the Raw Output, error: %s", err)
+		e.logger.Warnf("Failed to save the Raw Output: %s", err)
 	}
 
 	deployPth := filepath.Join(deployDir, "xcodebuild_test.log")
@@ -103,7 +103,7 @@ func (e exporter) ExportXcodebuildTestLog(deployDir, xcodebuildTestLog string) e
 	}
 
 	if err := e.envRepository.Set("BITRISE_XCODEBUILD_TEST_LOG_PATH", deployPth); err != nil {
-		e.logger.Warnf("Failed to export: BITRISE_XCODEBUILD_TEST_LOG_PATH, error: %s", err)
+		e.logger.Warnf("Failed to export: BITRISE_XCODEBUILD_TEST_LOG_PATH: %s", err)
 	}
 
 	return nil

--- a/output/utils.go
+++ b/output/utils.go
@@ -11,12 +11,12 @@ import (
 func saveRawOutputToLogFile(rawXcodebuildOutput string) (string, error) {
 	tmpDir, err := pathutil.NormalizedOSTempDirPath("xcodebuild-output")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp dir, error: %s", err)
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 	logFileName := "raw-xcodebuild-output.log"
 	logPth := filepath.Join(tmpDir, logFileName)
 	if err := fileutil.WriteStringToFile(logPth, rawXcodebuildOutput); err != nil {
-		return "", fmt.Errorf("failed to write xcodebuild output to file, error: %s", err)
+		return "", fmt.Errorf("failed to write xcodebuild output to file: %w", err)
 	}
 
 	return logPth, nil

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -187,7 +187,7 @@ func (m manager) SimulatorShutdown(id string) error {
 func (m manager) SimulatorDiagnosticsName() (string, error) {
 	timestamp, err := time.Now().MarshalText()
 	if err != nil {
-		return "", fmt.Errorf("failed to collect Simulator diagnostics, failed to marshal timestamp: %v", err)
+		return "", fmt.Errorf("failed to marshal timestamp: %w", err)
 	}
 
 	return fmt.Sprintf("simctl_diagnose_%s.zip", strings.ReplaceAll(string(timestamp), ":", "-")), nil

--- a/step/step.go
+++ b/step/step.go
@@ -366,7 +366,7 @@ func (s XcodeTestRunner) getSimulatorForDestination(destinationSpecifier string)
 func (s XcodeTestRunner) prepareSimulator(enableSimulatorVerboseLog bool, simulatorID string, launchSimulator bool) error {
 	err := s.simulatorManager.ResetLaunchServices()
 	if err != nil {
-		s.logger.Warnf("Failed to apply simulator boot workaround, error: %s", err)
+		s.logger.Warnf("Failed to apply simulator boot workaround: %s", err)
 	}
 
 	// Boot simulator

--- a/step/step.go
+++ b/step/step.go
@@ -171,7 +171,7 @@ func (s XcodeTestRunner) ProcessConfig() (Config, error) {
 	}
 
 	if input.RelaunchTestsForEachRepetition && input.TestRepetitionMode == xcodebuild.TestRepetitionNone {
-		return Config{}, errors.New("the Relaunch Tests for Each Repetition (relaunch_tests_for_each_repetition) cannot be used if Test Repetition Mode (test_repetition_mode) is 'none'")
+		return Config{}, errors.New("the 'Relaunch Tests for Each Repetition' (relaunch_tests_for_each_repetition) cannot be used if 'Test Repetition Mode' (test_repetition_mode) is 'none'")
 	}
 
 	return createConfig(input, projectPath, int(xcodebuildVersion.MajorVersion), sim), nil
@@ -322,7 +322,7 @@ func (s XcodeTestRunner) getSimulatorForDestination(destinationSpecifier string)
 
 	simulatorDestination, err := destination.NewSimulator(destinationSpecifier)
 	if err != nil {
-		return simulator.Simulator{}, fmt.Errorf("invalid destination specifier: %s: %w", destinationSpecifier, err)
+		return simulator.Simulator{}, fmt.Errorf("invalid destination specifier (%s): %w", destinationSpecifier, err)
 	}
 
 	platform := strings.TrimSuffix(simulatorDestination.Platform, " Simulator")

--- a/testaddon/utils.go
+++ b/testaddon/utils.go
@@ -22,7 +22,7 @@ func replaceUnsupportedFilenameCharacters(s string) string {
 
 func copyDirectory(sourceBundle string, targetDir string) error {
 	if err := os.MkdirAll(targetDir, 0700); err != nil {
-		return fmt.Errorf("failed to create directory (%s), error: %s", targetDir, err)
+		return fmt.Errorf("failed to create directory (%s): %w", targetDir, err)
 	}
 
 	// the leading `/` means to copy not the content but the whole dir
@@ -32,7 +32,7 @@ func copyDirectory(sourceBundle string, targetDir string) error {
 	// TODO: migrate log
 	log.Donef("$ %s", cmd.PrintableCommandArgs())
 	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
-		return fmt.Errorf("copy failed, error: %s, output: %s", err, out)
+		return fmt.Errorf("copy failed: %w, output: %s", err, out)
 	}
 
 	return nil
@@ -47,10 +47,10 @@ func saveBundleMetadata(outputDir string, bundleName string) error {
 		BundleName: bundleName,
 	})
 	if err != nil {
-		return fmt.Errorf("could not encode metadata, error: %s", err)
+		return fmt.Errorf("could not encode metadata: %w", err)
 	}
 	if err = ioutil.WriteFile(filepath.Join(outputDir, "test-info.json"), bytes, 0600); err != nil {
-		return fmt.Errorf("failed to write file, error: %s", err)
+		return fmt.Errorf("failed to write file: %w", err)
 	}
 	return nil
 }

--- a/xcodebuild/utils.go
+++ b/xcodebuild/utils.go
@@ -223,11 +223,11 @@ func (b *xcodebuild) createXCPrettyArgs(options string) ([]string, error) {
 	}
 	if xcprettyOutputFilePath != "" {
 		if isExist, err := b.pathChecker.IsPathExists(xcprettyOutputFilePath); err != nil {
-			b.logger.Errorf("Failed to check xcpretty output file status (path: %s), error: %s", xcprettyOutputFilePath, err)
+			b.logger.Errorf("Failed to check xcpretty output file status (path: %s): %s", xcprettyOutputFilePath, err)
 		} else if isExist {
 			b.logger.Warnf("=> Deleting existing xcpretty output: %s", xcprettyOutputFilePath)
 			if err := b.fileManager.Remove(xcprettyOutputFilePath); err != nil {
-				b.logger.Errorf("Failed to delete xcpretty output file (path: %s), error: %s", xcprettyOutputFilePath, err)
+				b.logger.Errorf("Failed to delete xcpretty output file (path: %s): %w", xcprettyOutputFilePath, err)
 			}
 		}
 	}
@@ -286,7 +286,7 @@ func (b *xcodebuild) handleTestRunError(prevRunParams TestRunParams, prevRunResu
 	if prevRunParams.RetryOnSwiftPackageResolutionError && prevRunParams.SwiftPackagesPath != "" && isStringFoundInOutput(cache.SwiftPackagesStateInvalid, prevRunResult.xcodebuildLog) {
 		log.RWarnf("xcode-test", "swift-packages-cache-invalid", nil, "swift packages cache is in an invalid state")
 		if err := b.fileManager.RemoveAll(prevRunParams.SwiftPackagesPath); err != nil {
-			b.logger.Errorf("failed to remove Swift package caches, error: %s", err)
+			b.logger.Errorf("failed to remove Swift package caches: %s", err)
 			return prevRunResult.xcodebuildLog, prevRunResult.exitCode, prevRunResult.err
 		}
 

--- a/xcodebuild/utils.go
+++ b/xcodebuild/utils.go
@@ -231,7 +231,7 @@ func (b *xcodebuild) createXCPrettyArgs(options string) ([]string, error) {
 			}
 		}
 	}
-	//
+
 	args = append(args, opts...)
 
 	return args, nil

--- a/xcpretty/xcpretty.go
+++ b/xcpretty/xcpretty.go
@@ -39,19 +39,19 @@ func (i installer) Install() (*version.Version, error) {
 
 		cmdModelSlice, err := i.xcpretty.Install()
 		if err != nil {
-			return nil, fmt.Errorf("failed to install xcpretty: %s", err)
+			return nil, fmt.Errorf("failed to create xcpretty commands: %w", err)
 		}
 
 		for _, cmd := range cmdModelSlice {
 			if err := cmd.Run(); err != nil {
-				return nil, fmt.Errorf("failed to install xcpretty: %s", err)
+				return nil, fmt.Errorf("failed to run xcpretty install command (%s): %w", cmd.PrintableCommandArgs(), err)
 			}
 		}
 	}
 
 	xcprettyVersion, err := i.xcpretty.Version()
 	if err != nil {
-		return nil, fmt.Errorf("failed to determine xcpretty version: %s", err)
+		return nil, fmt.Errorf("failed to get xcpretty version: %w", err)
 	}
 	return xcprettyVersion, nil
 }

--- a/xcpretty/xcpretty.go
+++ b/xcpretty/xcpretty.go
@@ -39,7 +39,7 @@ func (i installer) Install() (*version.Version, error) {
 
 		cmdModelSlice, err := i.xcpretty.Install()
 		if err != nil {
-			return nil, fmt.Errorf("failed to create xcpretty commands: %w", err)
+			return nil, fmt.Errorf("failed to create xcpretty install commands: %w", err)
 		}
 
 		for _, cmd := range cmdModelSlice {


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

Adding more context to error messages printed to the build log.

### Changes

- Top-level input parsing errors got a new format: `Process config: %s`
- Top-level step run errors got a new format: `Run: %s`
- Top-level step dependency install got a new format: `Export outputs: %s`
- Improved error messages
  - removed `, error: ` suffixes from error messages
  - use `%w` for wrapping errors
