### PR TITLE
[NOJIRA] Support only Xcode version at least 11

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -36,28 +36,8 @@ workflows:
     - _check_exported_artifacts
     - _check_xcpretty_html_report
 
+  # Requires Xcode 11+
   test_test_plan:
-    before_run:
-    - _expose_xcode_version
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/env bash
-            set -e
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode >= 11, skipping..."
-              exit 0
-            fi
-            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-    - bitrise-run:
-        run_if: |-
-          {{ enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true" }}
-        inputs:
-        - workflow_id: utility_test_test_plan
-        - bitrise_config_path: ./e2e/bitrise.yml
-
-  utility_test_test_plan:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/sample-swift-project-with-parallel-ui-test.git
     - TEST_APP_BRANCH: master


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Require at least Xcode version 11.
As the code changes can no longer be tested below this version (and xcresult bundle support also requires it), it is time to formally deprecate old Xcode support.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
