### PR TITLE
Add Apple Silicon compatibility mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func createConfigParser(logger log.Logger) step.XcodeTestConfigParser {
 	deviceFinder := destination.NewDeviceFinder(logger, commandFactory)
 	utils := step.NewUtils(logger)
 
-	return step.NewXcodeTestConfigParser(inputParser, logger, xcodeVersionReader, deviceFinder, pathModifier, utils)
+	return step.NewXcodeTestConfigParser(inputParser, logger, xcodeVersionReader, deviceFinder, pathModifier, utils, envRepository)
 }
 
 func createStep(logger log.Logger, logFormatter string) (step.XcodeTestRunner, error) {

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -312,7 +312,7 @@ func createConfigParser(t *testing.T, envValues map[string]string) (XcodeTestCon
 	pathModifier := mocks.NewPathModifier(t)
 	utils := NewUtils(logger)
 
-	configParser := NewXcodeTestConfigParser(inputParser, logger, xcodeVersionReader, deviceFinder, pathModifier, utils)
+	configParser := NewXcodeTestConfigParser(inputParser, logger, xcodeVersionReader, deviceFinder, pathModifier, utils, envRepository)
 	mocks := configParserMocks{
 		xcodeVersion: xcodeVersionReader,
 		deviceFinder: deviceFinder,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

EXCLUDED_ARCH is the modern way to resolve linking issues when building for `arm64` simulator destinations: https://developer.apple.com/documentation/technotes/tn3117-resolving-build-errors-for-apple-silicon

### Changes

This PR adds support for controlling this build setting "from the outside". The step already has an input for additional build flags, the user can always define this setting manually.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
