### PR TITLE
Add visionOS support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.18
 	github.com/bitrise-io/go-utils v1.0.9
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.19
-	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.34
+	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.36
 	github.com/hashicorp/go-version v1.6.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/bitrise-io/go-utils v1.0.9 h1:wy7FewUpseNSTZr41BbGH0csfFqzptFt4zy2pOA
 github.com/bitrise-io/go-utils v1.0.9/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.19 h1:55as5Iv0N4btuRP3YwRzN+BCMtKO210MnJ8mpxmeI7o=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.19/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.34 h1:Gp5ss+Zm44X4gOxaGcovPp5rY9kSCKdWOVTkaxfDtlE=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.34/go.mod h1:LzUnQjIUOZ18XggzZNZgyoETxpX637T646lyc0h6oDQ=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.36 h1:X0eYAHxpeK1i/4yyU5XAqfMdap3t1nXFEUxOlxFIQ0I=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.36/go.mod h1:Y3K7ay6Q+znVKFmGGvr4jijnN8QmTBxB5+CatRtBl30=
 github.com/bitrise-io/stepman v0.0.0-20230728094915-939f0fe5c19a h1:XM2PrNSUjpI4pIOZ1TcZdD4kh7KYN2D+yC6WYy22hoo=
 github.com/bitrise-io/stepman v0.0.0-20230728094915-939f0fe5c19a/go.mod h1:Z46oQnRMHlbuiV0mCJBigT2bWO5j3TPQncKaL3jCwsk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/github.com/bitrise-io/go-xcode/v2/destination/destination.go
+++ b/vendor/github.com/bitrise-io/go-xcode/v2/destination/destination.go
@@ -18,14 +18,16 @@ type Platform string
 
 // Platforms ...
 const (
-	MacOS            Platform = "macOS"
-	IOS              Platform = "iOS"
-	IOSSimulator     Platform = "iOS Simulator"
-	WatchOS          Platform = "watchOS"
-	WatchOSSimulator Platform = "watchOS Simulator"
-	TvOS             Platform = "tvOS"
-	TvOSSimulator    Platform = "tvOS Simulator"
-	DriverKit        Platform = "DriverKit"
+	MacOS             Platform = "macOS"
+	IOS               Platform = "iOS"
+	IOSSimulator      Platform = "iOS Simulator"
+	WatchOS           Platform = "watchOS"
+	WatchOSSimulator  Platform = "watchOS Simulator"
+	TvOS              Platform = "tvOS"
+	TvOSSimulator     Platform = "tvOS Simulator"
+	DriverKit         Platform = "DriverKit"
+	VisionOS          Platform = "visionOS"
+	VisionOSSimulator Platform = "visionOS Simulator"
 )
 
 // Specifier ...
@@ -52,7 +54,7 @@ func NewSpecifier(destination string) (Specifier, error) {
 	return specifier, nil
 }
 
-// Platform ...
+// Platform returns the platform part of the specifier and true if it's the generic platform
 func (s Specifier) Platform() (Platform, bool) {
 	p, ok := s[genericPlatformKey]
 	if ok {

--- a/vendor/github.com/bitrise-io/go-xcode/v2/destination/parse.go
+++ b/vendor/github.com/bitrise-io/go-xcode/v2/destination/parse.go
@@ -303,7 +303,12 @@ func (d deviceFinder) runtimeForPlatformVersion(wantedPlatform, wantedVersion st
 
 		if runtime.Platform != "" && runtime.Platform == string(wantedPlatform) {
 			runtimesOfPlatform = append(runtimesOfPlatform, runtime)
+			continue
+		}
 
+		// simctl reports visionOS as xrOS (as of Xcode 15.1 Beta 3)
+		if (runtime.Platform == "xrOS" || runtime.Platform == "visionOS") && wantedPlatform == string(VisionOS) {
+			runtimesOfPlatform = append(runtimesOfPlatform, runtime)
 			continue
 		}
 
@@ -331,6 +336,9 @@ func (d deviceFinder) runtimeForPlatformVersion(wantedPlatform, wantedVersion st
 		}
 		if wantedPlatform == string(TvOS) {
 			return deviceRuntime{}, fmt.Errorf("the platform %s is unavailable. Did you mean %s?", wantedPlatform, TvOSSimulator)
+		}
+		if wantedPlatform == string(VisionOS) {
+			return deviceRuntime{}, fmt.Errorf("the platform %s is unavailable. Did you mean %s?", wantedPlatform, VisionOSSimulator)
 		}
 		return deviceRuntime{}, fmt.Errorf("no runtime installed for platform %s", wantedPlatform)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,7 +44,7 @@ github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/log/colorstring
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.34
+# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.36
 ## explicit; go 1.20
 github.com/bitrise-io/go-xcode/v2/destination
 github.com/bitrise-io/go-xcode/v2/errorfinder


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Initial visionOS support just to let the tests start. Things are still very unstable and unreliable (I couldn't run a single test E2E because of random Mach IPC errors), so I'm not adding any tests yet.

### Changes

Update `go-xcode` with the updated platform handling logic that recognizes `visionOS` and handles the `xrOS` vs. `visionOS` edge case.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
